### PR TITLE
Completion functions and annotations

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -5281,36 +5281,6 @@ RECIPE is a straight.el-style plist."
 ;;;; Interactive helpers
 ;;;;; Package selection
 
-(defconst straight--recipe-completion-metadata
-  `((category . straight-recipe))
-  "Metadata to be passed to `completing-read' when selecting packages.")
-
-(defun straight--recipe-completion (recipes)
-  "Completion function for recipe names listed in RECIPES."
-  (lambda (string pred action)
-    (pcase action
-      ('metadata
-       (cons 'metadata straight--recipe-completion-metadata))
-      (_
-       (complete-with-action action recipes string pred)))))
-
-(defun straight--cached-recipe-completion (&optional filter)
-  "Completion function for cached recipe names.
-Candidates are the keys of `straight--recipe-cache'.
-
-See documentation of `straight--select-package' for a description
-of FILTER."
-  (lambda (string pred action)
-    (pcase action
-      ('metadata
-       (cons 'metadata straight--recipe-completion-metadata))
-      (_
-       (complete-with-action
-        action straight--recipe-cache string
-        (lambda (package recipe)
-          (and (or (null filter) (funcall filter recipe))
-               (or (null pred) (funcall pred package)))))))))
-
 (defun straight--select-package (message &optional filter)
   "Use `completing-read' to select a package.
 MESSAGE is displayed as the prompt; it should not end in punctuation
@@ -5320,9 +5290,120 @@ FILTER is a function accepting one argument: a straight style recipe plist.
 If it returns nil, the package is not considered a selection candidate."
   (completing-read
    (concat message ": ")
-   (straight--cached-recipe-completion filter)
+   (straight--package-completion straight--recipe-cache filter)
    nil
    'require-match))
+
+;;;;;; Completion functions
+
+(defun straight--package-completion (recipes &optional filter)
+  "Make a completion function for package names.
+RECIPES is a hash table like `straight--recipe-cache', mapping
+package name strings to recipes.
+
+See documentation of `straight--select-package' for a description
+of FILTER."
+  (let* ((annotfn (straight--package-annotation recipes))
+         (metadata `(metadata (category . straight-recipe)
+                              (annotation-function . ,annotfn))))
+    (lambda (string pred action)
+      (if (eq action 'metadata)
+          metadata
+        (complete-with-action
+         action recipes string
+         (lambda (package recipe)
+           (and (or (null filter) (funcall filter recipe))
+                (or (null pred) (funcall pred package)))))))))
+
+(defun straight--recipe-completion (sources &optional cause)
+  "Make a completion function for recipes available in SOURCES.
+The completion candidates are the same as those returned by
+`straight-recipes-list'.
+
+SOURCES should be a list that is a subset of
+`straight-recipe-repositories'.
+
+CAUSE is a string indicating why recipe repositories might need
+to be cloned."
+  (let* ((recipes (make-hash-table :test #'equal))
+         (annotfn (straight--recipe-annotation recipes))
+         (metadata `(metadata (category . straight-recipe)
+                              (annotation-function . ,annotfn))))
+    (dolist (source sources)
+      (let ((cause (concat cause (when cause straight-arrow)
+                           (format "Listing %S recipes" source))))
+        (dolist (recipe (straight-recipes 'list source cause))
+          (unless (gethash recipe recipes) (puthash recipe source recipes)))))
+    (lambda (string pred action)
+      (if (eq action 'metadata)
+          metadata
+        (complete-with-action action recipes string pred)))))
+
+;;;;;; Annotation functions
+
+(defun straight--package-annotation (recipes)
+  "Make an annotation function for keys of RECIPES.
+See documentation of `straight--package-completion' for a
+description of RECIPES.
+
+Each package is annotated with its installation status (installed
+or built-in) and its remote repository."
+  (let ((annotfmt
+         (propertize
+          (concat (propertize " " 'display '(space :align-to 40)) " %s"
+                  (propertize " " 'display '(space :align-to 51)) " %s")
+          'face 'completions-annotations)))
+    (lambda (package)
+      (let* ((recipe (gethash package recipes))
+             (remote (straight--recipe-annotation-remote recipe)))
+        (straight--with-plist recipe (type)
+          (format annotfmt
+                  (cond
+                   ((eq type 'built-in) "built-in")
+                   ((straight--installed-p recipe) "installed")
+                   (t ""))
+                  (or remote "")))))))
+
+(defun straight--recipe-annotation (recipes)
+  "Make an annotation function for keys of RECIPES.
+RECIPES is a hash table mapping package name strings to their
+respective sources, which are elements of
+`straight-recipe-repositories'.
+
+Each package is annotated with its source and, if available, its
+remote repository.  The remote repository is shown only if the
+package's recipe from the correct source has previously been
+retrieved by `straight-recipes-retrieve', which caches it in
+`straight--recipe-lookup-cache'."
+  (let ((annotfmt
+         (propertize
+          (concat (propertize " " 'display '(space :align-to 40)) " %s"
+                  (propertize " " 'display '(space :align-to 60)) " %s")
+          'face 'completions-annotations)))
+    (lambda (package)
+      (let* ((source (gethash package recipes))
+             (table (gethash source straight--recipe-lookup-cache))
+             (recipe (and table (gethash package table)))
+             (remote (and recipe (straight--recipe-annotation-remote
+                                  (straight--convert-recipe recipe)))))
+        (format annotfmt source (or remote ""))))))
+
+(defun straight--recipe-annotation-remote (recipe)
+  "The remote repository of RECIPE in human-readable form.
+Suitable for annotating the recipe with its origin in completion functions.
+
+Returns a string, or nil if the remote repository could not be
+determined."
+  (ignore-errors
+    (straight--with-plist recipe (type)
+      (when (eq type 'git)
+        (straight-vc-git--destructure recipe (repo host)
+          (replace-regexp-in-string     ; Remove extraneous URL components...
+           (rx bos (? (*? anything) ":" (? "//")) ; prefix "protocol://"
+               (group (*? anything))              ; keep this part
+               (? ".git") eos)                   ; suffix ".git"
+           "\\1"
+           (straight-vc-git--encode-url repo host 'https)))))))
 
 ;;;;; Bookkeeping
 
@@ -5502,8 +5583,7 @@ action, just return it)."
          (package
           (intern (completing-read
                    "Which recipe? "
-                   (straight--recipe-completion
-                    (straight-recipes-list sources))
+                   (straight--recipe-completion sources)
                    nil
                    'require-match)))
          ;; No need to provide a `cause' to

--- a/straight.el
+++ b/straight.el
@@ -5297,9 +5297,8 @@ If it returns nil, the package is not considered a selection candidate."
 ;;;;;; Completion functions
 
 (defun straight--package-completion (recipes &optional filter)
-  "Make a completion function for package names.
-RECIPES is a hash table like `straight--recipe-cache', mapping
-package name strings to recipes.
+  "Return a  package name completion function.
+RECIPES must be a hash table mapping package name strings to recipes.
 
 See documentation of `straight--select-package' for a description
 of FILTER."
@@ -5316,7 +5315,7 @@ of FILTER."
                 (or (null pred) (funcall pred package)))))))))
 
 (defun straight--recipe-completion (sources &optional cause)
-  "Make a completion function for recipes available in SOURCES.
+  "Return a completion function for recipes in SOURCES.
 The completion candidates are the same as those returned by
 `straight-recipes-list'.
 
@@ -5342,7 +5341,7 @@ to be cloned."
 ;;;;;; Annotation functions
 
 (defun straight--package-annotation (recipes)
-  "Make an annotation function for keys of RECIPES.
+  "Return an annotation function for RECIPES keys.
 See documentation of `straight--package-completion' for a
 description of RECIPES.
 


### PR DESCRIPTION
This patch modifies `straight--select-package` and `straight--get-recipe` to use completion functions instead of tables. The completion function allows for
* Setting the completion category to `'straight-recipe`, which is useful for packages like Embark.
* Showing extra metadata when the completion UI supports annotations (see screenshot below, using Vertico).

![image](https://user-images.githubusercontent.com/552952/139419412-a6625eac-14f2-4838-83b4-e0847d16f23a.png)
