### PR TITLE
straight--add-package-to-info-path: Only add dirs with "dir" file

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -5221,19 +5221,19 @@ package has already been built."
 RECIPE is a straight.el-style plist. It is assumed that the
 package has already been built. This function calls
 `info-initialize'."
-  (straight--with-plist recipe
-      (package)
-    ;; The `info-initialize' function is not autoloaded, for some
-    ;; reason. Do `eval-and-compile' for the byte-compiler.
-    (eval-and-compile
-      (require 'info))
-    ;; Initialize the `Info-directory-list' variable. We have to do
-    ;; this before adding to it, since otherwise the default paths
-    ;; won't get added later.
-    (info-initialize)
-    ;; Actually add the path. Only .info files at the top level will
-    ;; be seen, which is fine. (It's the way MELPA works.)
-    (add-to-list 'Info-directory-list (straight--build-dir package))))
+  (let ((package (plist-get recipe :package)))
+    (when (file-exists-p (straight--build-file package "dir"))
+      ;; The `info-initialize' function is not autoloaded, for some
+      ;; reason. Do `eval-and-compile' for the byte-compiler.
+      (eval-and-compile
+        (require 'info))
+      ;; Initialize the `Info-directory-list' variable. We have to do
+      ;; this before adding to it, since otherwise the default paths
+      ;; won't get added later.
+      (info-initialize)
+      ;; Actually add the path. Only .info files at the top level will
+      ;; be seen, which is fine. (It's the way MELPA works.)
+      (add-to-list 'Info-directory-list (straight--build-dir package)))))
 
 (defun straight--load-package-autoloads (package)
   "Load autoloads provided by PACKAGE, a string, from disk."

--- a/tests/straight-test.el
+++ b/tests/straight-test.el
@@ -161,9 +161,8 @@ return nil."
         (Info-directory-list '()))
     (straight--add-package-to-info-path
      '(:package "straight-mock-repo" :local-repo "./test-repo"))
-    (should (string= ".emacs.d/straight/build/straight-mock-repo/"
-                     (straight-test-trim-to-mocks
-                      (car Info-directory-list))))))
+    ;; No "dir" file, so this directory does not get added
+    (should (null Info-directory-list))))
 
 (straight-deftest straight--alist-set ()
   (should (equal ',out (straight--alist-set ,@in)))


### PR DESCRIPTION
Reduces info lookup/search time.
See: https://github.com/radian-software/straight.el/discussions/950

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
