### PR TITLE
-recipes-org-elpa-retrieve: remove stale org-contrib :includes

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -3175,24 +3175,24 @@ Otherwise return nil."
     ('org-contrib
      (list package
            :type 'git
-           :includes '(ob-arduino ; Intentionally short for indentation
-                       ob-clojure-literate ob-csharp ob-eukleides
-                       ob-fomus ob-julia ob-mathematica ob-mathomatic ob-oz
-                       ob-php ob-redis ob-sclang ob-smiles ob-spice ob-stata
+           :includes '(;; Intentionally blank for indentation.
+                       ob-csharp ob-eukleides
+                       ob-fomus ob-julia ob-mathomatic ob-oz
+                       ob-stata
                        ob-tcl ob-vbnet ol-bookmark ol-elisp-symbol ol-git-link
-                       ol-man ol-mew ol-notmuch ol-vm ol-wl org-annotate-file
-                       org-attach-embedded-images org-bibtex-extras
-                       org-checklist org-choose org-collector org-contacts
+                       ol-man ol-mew ol-vm ol-wl org-annotate-file
+                       org-bibtex-extras
+                       org-checklist org-choose org-collector
                        org-contribdir org-depend org-effectiveness org-eldoc
                        org-eval org-eval-light org-expiry
                        org-interactive-query org-invoice org-learn org-license
-                       org-mac-iCal org-mac-link org-mairix org-notify
-                       org-panel org-passwords org-registry org-screen
+                       org-mac-iCal org-mairix
+                       org-panel org-registry org-screen
                        org-screenshot org-secretary org-static-mathjax
                        org-sudoku orgtbl-sqlinsert org-toc org-track
-                       org-velocity org-wikinodes ox-bibtex ox-confluence
+                       org-wikinodes ox-bibtex ox-confluence
                        ox-deck ox-extra ox-freemind ox-groff ox-koma-letter
-                       ox-rss ox-s5 ox-taskjuggler)
+                       ox-s5 ox-taskjuggler)
            :repo "https://git.sr.ht/~bzg/org-contrib"
            :files '(:defaults "lisp/*.el")))))
 
@@ -3202,7 +3202,7 @@ Otherwise return nil."
 
 (defun straight-recipes-org-elpa-version ()
   "Return the current version of the Org ELPA retriever."
-  13)
+  14)
 
 ;;;;;; MELPA
 


### PR DESCRIPTION
Various packages have been adopted and moved out of org-contrib:

https://git.sr.ht/~bzg/org-contrib/refs/release_0.4

Also see #952.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

Please create pull requests against the develop branch only!

-->
