### PR TITLE
Rephrase README that native-comp is now in emacs/master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1741,11 +1741,10 @@ recipes which do not explicitly disable byte-compilation via the
 
 ##### Native compilation
 
-Experimental support for native compilation of Emacs Lisp code is
-currently under development in the `feature/native-comp` branch of the
-official Emacs repository (see [gccemacs][gccemacs]). When running on
-this version of Emacs, `straight.el` will perform native compilation
-of packages.
+Experimental support for native compilation of Emacs Lisp code can be
+enabled in the latest `master` branch of the official Emacs repository
+(see [gccemacs][gccemacs]). When running on this version of Emacs,
+`straight.el` will perform native compilation of packages.
 
 By specifying a `:build (:not native-compile)` in a package's recipe,
 you may inhibit native compilation. You can also customize the


### PR DESCRIPTION
The readme mentioned that native-compilation is under development under the native-comp branch of emacs. However, this feature has already been merged into master and will be available in emacs 29 as far as I understand. However, even though it's merged, the `--with-native-compilation`  flag is disabled by default.