### PR TITLE
Update for Emacs 29 where loaddefs-gen.el replaces autoloads.el

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -5098,14 +5098,15 @@ modifies the build folder, not the original repository."
   ;; it out, then straight.el will fail with a mysterious error and
   ;; then cause Emacs to segfault if you start it with --debug-init.
   ;; This happens because if you take out `eval-and-compile', then
-  ;; `autoload' will not be loaded at byte-compile time, and therefore
-  ;; `generated-autoload-file' is not defined as a variable. Thus
-  ;; Emacs generates bytecode corresponding to a lexical binding of
-  ;; `generated-autoload-file', and then chokes badly when
-  ;; `generated-autoload-file' turns into a dynamic variable at
-  ;; runtime.
+  ;; `autoload'/`loaddefs-gen’ will not be loaded at byte-compile
+  ;; time, and therefore `generated-autoload-file' is not defined as a
+  ;; variable. Thus Emacs generates bytecode corresponding to a
+  ;; lexical binding of `generated-autoload-file', and then chokes
+  ;; badly when `generated-autoload-file' turns into a dynamic
+  ;; variable at runtime.
   (eval-and-compile
-    (require 'autoload))
+    (or (require 'loaddefs-gen nil 'noerror)
+        (require 'autoload)))
   (straight--with-plist recipe
       (package)
     (let (;; The full path to the autoload file.
@@ -5139,14 +5140,19 @@ modifies the build folder, not the original repository."
               ;; Non-nil interferes with autoload generation in Emacs < 29, see
               ;; <https://github.com/radian-software/straight.el/issues/904>.
               (left-margin 0))
-          ;; Actually generate the autoload file.
-          ;; Emacs > 28.1 replaces `update-directory-autoloads' with
-          ;; `make-directory-autoloads'
-          (if (fboundp 'make-directory-autoloads)
-              (make-directory-autoloads (straight--build-dir package)
-                                        generated-autoload-file)
-            (and (fboundp 'update-directory-autoloads)
-                 (update-directory-autoloads (straight--build-dir package)))))
+          ;; Actually generate the autoload file. Emacs 28.1 replaces
+          ;; `update-directory-autoloads' with
+          ;; `make-directory-autoloads', and Emacs 29 with
+          ;; `loaddefs-generate’
+          (cond
+           ((fboundp 'loaddefs-generate)
+            (loaddefs-generate (straight--build-dir package)
+                               generated-autoload-file))
+           ((fboundp 'make-directory-autoloads)
+            (make-directory-autoloads (straight--build-dir package)
+                                      generated-autoload-file))
+           ((fboundp 'update-directory-autoloads)
+            (update-directory-autoloads (straight--build-dir package)))))
         ;; And for some reason Emacs leaves a newly created buffer
         ;; lying around. Let's kill it.
         (when-let ((buf (find-buffer-visiting generated-autoload-file)))


### PR DESCRIPTION
Fixes issue #985.

I believe this may be what is needed, but I haven’t tested it extensively yet.