### PR TITLE
Adding straight-visit-package-local-repo

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -5655,6 +5655,16 @@ If SOURCES is nil, update sources in `straight-recipe-repositories'."
         ('gitlab (browse-url (format "https://gitlab.com/%s" repo)))
         (_ (browse-url (format "%s" repo)))))))
 
+;;;;; Open a package repo
+
+;;;###autoload
+(defun straight-visit-package-local-repo ()
+  "Interactively select a recipe, and open the package's local directory."
+  (interactive)
+  (find-file (straight--repos-dir
+              (straight--select-package "Package"
+                                        #'straight--installed-p))))
+  
 ;;;;; Package registration
 
 (defcustom straight-use-package-prepare-functions nil

--- a/straight.el
+++ b/straight.el
@@ -5655,7 +5655,6 @@ If SOURCES is nil, update sources in `straight-recipe-repositories'."
         ('gitlab (browse-url (format "https://gitlab.com/%s" repo)))
         (_ (browse-url (format "%s" repo)))))))
 
-;;;;; Open a package repo
 
 ;;;###autoload
 (defun straight-visit-package (package &optional build)

--- a/straight.el
+++ b/straight.el
@@ -5660,9 +5660,11 @@ If SOURCES is nil, update sources in `straight-recipe-repositories'."
 (defun straight-visit-package (package &optional build)
   "Open PACKAGE's local repository directory.
 When BUILD is non-nil visit PACKAGE's build directory."
-  (interactive (list (straight--select-package "Package" #'straight--installed-p)
-                     current-prefix-arg))
-  (let ((dir (funcall (if build #'straight--build-dir #'straight--repos-dir) package)))
+  (interactive
+   (list (straight--select-package "Package" #'straight--installed-p)
+         current-prefix-arg))
+  (let ((dir (funcall (if build #'straight--build-dir #'straight--repos-dir)
+                      package)))
     (if (file-exists-p dir)
         (find-file dir)
       (user-error "Directory does not exist: %S" dir))))

--- a/straight.el
+++ b/straight.el
@@ -5658,12 +5658,15 @@ If SOURCES is nil, update sources in `straight-recipe-repositories'."
 ;;;;; Open a package repo
 
 ;;;###autoload
-(defun straight-visit-package-local-repo ()
-  "Interactively select a recipe, and open the package's local directory."
-  (interactive)
-  (find-file (straight--repos-dir
-              (straight--select-package "Package"
-                                        #'straight--installed-p))))
+(defun straight-visit-package (package &optional build)
+  "Open PACKAGE's local repository directory.
+When BUILD is non-nil visit PACKAGE's build directory."
+  (interactive (list (straight--select-package "Package" #'straight--installed-p)
+                     current-prefix-arg))
+  (let ((dir (funcall (if build #'straight--build-dir #'straight--repos-dir) package)))
+    (if (file-exists-p dir)
+        (find-file dir)
+      (user-error "Directory does not exist: %S" dir))))
   
 ;;;;; Package registration
 


### PR DESCRIPTION
This PR adds a interactive function to visit the local-repo of an installed package. I had this in my local config, which I find very helpful. Figured I'd add it here itself.
