### PR TITLE
Fix typo in "Pseudo" for nil/built-in docstrings

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -1542,7 +1542,7 @@ This method simply delegates to the relevant
                         "merge-from-upstream"
                         "push-to-remote"))
     (defalias (intern (format "straight-vc-%S-%s" type method)) #'ignore
-      (format "Psuedo VC backend method for packages with :type %S." type))))
+      (format "Pseudo VC backend method for packages with :type %S." type))))
 
 ;;;;; Git
 


### PR DESCRIPTION
Fix typo in the word "Pseudo" in the documentation string for `nil` and `built-in` functions.
