### PR TITLE
Do not test against Emacs master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        emacs_version: [25, 26, 27, "master"]
+        emacs_version: [25, 26, 27, 28]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request: {}
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
cc @progfolio - trying to unbreak CI for https://github.com/radian-software/straight.el/pull/931. I've been doing this on other Emacs projects as well because I have found that testing against Emacs master introduces a lot of flakiness and generally imposes maintenance burden that doesn't seem to have a good return on investment given that we have limited resources.

In the medium-term future, I plan to make further changes to my Emacs projects to increase their maintainability and make it possible for me to do more active maintenance of all of them, including `straight.el`. I really appreciate that you already started effort in that direction by adding some tests. I should have done that in the first place, and I will likely add more in the future.