### PR TITLE
straight-use-version-specific-build-dir: fix docstring single quotes

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -608,10 +608,10 @@ Defaults to `user-emacs-directory'."
 (defcustom straight-use-version-specific-build-dir nil
   "If non-nil, use an Emacs-version-specific `straight-build-dir' directory.
 Normally, straight.el uses a single build directory and throws
-'emacs-version-changed when attempting to run the byte-compiled
+\\='emacs-version-changed when attempting to run the byte-compiled
 code in a different version of Emacs. This changes that behavior
 to use a per-Emacs-version build directory based upon the
-variable `emacs-version', for example 'build-27.2'.
+variable `emacs-version', for example `build-27.2'.
 
 Setting `straight-build-dir' will override this behavior."
   :type 'boolean)


### PR DESCRIPTION
Emacs 29+ byte-compiler warns about unescaped single quotes.

