### PR TITLE
straight--compute-dependencies: fix multiline metadata processing

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -5089,10 +5089,16 @@ this run of straight.el)."
                  ;; missing or malformed, we just assume the package
                  ;; has no dependencies.
                  (let ((case-fold-search t))
-                   (re-search-forward "^;* *Package-Requires *: *"))
-                 (when (looking-at "(")
-                   (straight--process-dependencies
-                    (read (current-buffer)))))))))
+                   (re-search-forward "^;* *Package-Requires *: *")
+                   (when-let ((required (list (buffer-substring-no-properties
+                                               (point) (line-end-position)))))
+                     (forward-line 1)
+                     ;; Borrowed from `lm-header-multiline'
+                     (while (looking-at "^;+\\(\t\\|[\t\s]\\{2,\\}\\)\\(.+\\)")
+                       (push (match-string-no-properties 2) required)
+                       (forward-line 1))
+                     (straight--process-dependencies
+                      (read (string-join (nreverse required) " "))))))))))
     (straight--insert 1 package dependencies straight--build-cache)))
 
 (defun straight--get-dependencies (package)


### PR DESCRIPTION
See #1028

<!-- copy entire buffer output and paste in an issue at:
https://github.com/radian-software/straight.el/issues/new/choose -->
<details open><summary>Test Case</summary>

```emacs-lisp
(straight-bug-report
  :pre-bootstrap 
  (setq straight-repository-user "progfolio" straight-repository-branch "fix/dependencies")
  :post-bootstrap 
  (straight-use-package 'epkg)
  (message "epkg dependencies: %S"
           (straight-dependencies "epkg")))
```
</details>

- Test run at: `2022-12-22 10:03:57`
- system-type: `gnu/linux`
- straight-version: `prerelease (HEAD -> fix/dependencies, fork/fix/dependencies) 2882980 2022-12-22`
- emacs-version: `GNU Emacs 30.0.50 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.24.35, cairo version 1.17.6)
 of 2022-12-18`

<details><summary>Output</summary>

```emacs-lisp
Bootstrapping straight.el...
Bootstrapping straight.el...done
Looking for gnu-elpa-mirror recipe → Cloning melpa...
Looking for gnu-elpa-mirror recipe → Cloning melpa...done
Looking for nongnu-elpa recipe → Cloning gnu-elpa-mirror...
Looking for nongnu-elpa recipe → Cloning gnu-elpa-mirror...done
Looking for emacsmirror-mirror recipe → Cloning nongnu-elpa...
Looking for emacsmirror-mirror recipe → Cloning nongnu-elpa...done
Looking for emacsmirror-mirror recipe → Cloning el-get...
Looking for emacsmirror-mirror recipe → Cloning el-get...done
Looking for straight recipe → Cloning emacsmirror-mirror...
Looking for straight recipe → Cloning emacsmirror-mirror...done
Building straight...
Building straight...done

Test run with version: prerelease (HEAD -> fix/dependencies, origin/fix/dependencies) 2882980 2022-12-22
Cloning epkg...
Cloning epkg...done
Building epkg...
Building epkg → Cloning compat...
Building epkg → Cloning compat...done
Building epkg → Building compat...
Building epkg → Building compat...done
Building epkg → Cloning closql...
Building epkg → Cloning closql...done
Building epkg → Building closql...
Building epkg → Building closql → Cloning emacsql (for emacsql-sqlite)...
Building epkg → Building closql → Cloning emacsql (for emacsql-sqlite)...done
Building epkg → Building closql → Building emacsql-sqlite...
Building epkg → Building closql → Building emacsql-sqlite → Building emacsql...
Building epkg → Building closql → Building emacsql-sqlite → Building emacsql...done
Building epkg → Building closql → Building emacsql-sqlite...
Building epkg → Building closql → Building emacsql-sqlite...done
Building epkg → Building closql...
Building epkg → Building closql...done
Building epkg → Cloning llama...
Building epkg → Cloning llama...done
Building epkg → Building llama...
Building epkg → Building llama...done
Building epkg...
Building epkg...done

epkg dependencies: (("compat" "nadvice") ("closql" ("compat" "nadvice") ("emacsql-sqlite" "emacsql")) ("llama" "seq"))
Packages:
"straight"                n/a                  fix/dependencies 2882980 2022-12-22
"org-elpa"                n/a                  n/a
"melpa"                   n/a                  master 835c996c 2022-12-20
"gnu-elpa-mirror"         n/a                  master eb11995 2022-12-15
"nongnu-elpa"             n/a                  main b552c02813 2022-12-21
"el-get"                  melpa                master d28d6179 2022-12-08
"emacsmirror-mirror"      n/a                  master 8bd0781 2022-12-22
"epkg"                    melpa                master cfdc4fc 2022-12-13
"compat"                  gnu-elpa-mirror      master 7ca7d30 2022-11-23
"closql"                  melpa                master 820e951 2022-10-20
"emacsql-sqlite"          melpa                master 6b2e65b 2022-11-27
"emacsql"                 melpa                master 6b2e65b 2022-11-27
"llama"                   melpa                main e919c6e 2022-11-26


```
</details>
