### PR TITLE
Fix parsing of nongnu-elpa recipes

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -3399,7 +3399,11 @@ Otherwise, return nil."
 
 (defun straight-recipes-nongnu-elpa-list ()
   "Return a list of NonGNU ELPA recipe names."
-  (mapcar (lambda (it) (symbol-name (car it)))
+  (mapcar (lambda (it)
+            (setq it (car it))
+            (when (symbolp it)
+              (setq it (symbol-name it)))
+            it)
           (straight-recipes-nongnu-elpa--recipes)))
 
 (defun straight-recipes-nongnu-elpa-version ()


### PR DESCRIPTION
Backwards compatibility so both the old and new formats work. See https://github.com/radian-software/straight.el/issues/1012, https://github.com/radian-software/straight.el/pull/1013.

This resolved `M-x straight-use-package` failing for me because I had an old checkout of NonGNU ELPA.