### PR TITLE
Reduce the size of the CI docker image

### DIFF
--- a/scripts/docker-install.bash
+++ b/scripts/docker-install.bash
@@ -35,7 +35,7 @@ install-info
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install -y $(grep -v "^#" <<< "$packages")
+apt-get install --no-install-recommends -y $(grep -v "^#" <<< "$packages")
 rm -rf /var/lib/apt/lists/*
 
 npm install -g markdown-toc


### PR DESCRIPTION
This PR reduces the size of the CI docker image by skipping the installation of Debian recommended packages.

The output for "apt-get install" is now:

``` 
0 upgraded, 212 newly installed, 0 to remove and 1 not upgraded. Need to get 48.3 MB of archives.
```

instead of:

```
0 upgraded, 457 newly installed, 0 to remove and 1 not upgraded. Need to get 204 MB of archives.
```