### PR TITLE
Use insert-file-contents when reading process stderr

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -936,10 +936,11 @@ If the process is unable to start, return an elisp error object."
                 nil args)
          (let ((s (buffer-substring-no-properties (point-min) (point-max))))
            (unless (string-empty-p s) s))
-         (progn (insert-file-contents
-                 straight--process-stderr nil nil nil 'replace)
-                (let ((s (buffer-substring-no-properties (point-min) (point-max))))
-                  (unless (string-empty-p s) s)))))
+         (progn
+           (insert-file-contents
+            straight--process-stderr nil nil nil 'replace)
+           (let ((s (buffer-substring-no-properties (point-min) (point-max))))
+             (unless (string-empty-p s) s)))))
     (error e)))
 
 (defmacro straight--process-with-result (result &rest body)

--- a/straight.el
+++ b/straight.el
@@ -937,12 +937,10 @@ If the process is unable to start, return an elisp error object."
                   nil args)
            (let ((s (buffer-string)))
              (unless (string-empty-p s) s))
-           (with-current-buffer
-               (find-file-noselect straight--process-stderr
-                                   'nowarn 'raw)
-             (prog1 (let ((s (buffer-string)))
-                      (unless (string-empty-p s) s))
-               (kill-buffer)))))
+           (with-temp-buffer
+             (insert-file-contents straight--process-stderr)
+             (let ((s (buffer-string)))
+               (unless (string-empty-p s) s)))))
       (error e))))
 
 (defmacro straight--process-with-result (result &rest body)


### PR DESCRIPTION
The function `straight--process-call` was using `find-file-noselect` to read in the standard error after the process exits. This apparently runs a bunch of hooks and potentially turns on minor modes, which can be disruptive and slow. (Context of the particular issue I had is below.)

It seems like the recommended way to just read a file to a string is `with-temp-buffer` and `insert-file-contents`. See, for example, top answer to “[What's wrong with `find-file-noselect`?](https://emacs.stackexchange.com/a/2898/21511)” on stackexchange.

So I think this should be an invisible, work-alike improvement to an internal function.

Now, for my context: I'm using `undo-tree`, and by default, `undo-tree-auto-save-history` so that undo info is saved across killing and reopening the file or restarting Emacs. I also configured the recommend advice to gzip the undo-tree files, which by default is verbose.

With that configuration in place, whenever I ran a batch straight process such as `straight-freeze-versions` or `straight-normalize-all` or `straight-fetch-all`, the useful echo-area progress output of straight would be completely overwhelmed by repeated "compressing undo-tree" messages referencing the `straight-stderr-NNNN` file... something like this:

```
Processing repository "rainbow-mode"...
compressing .straight-stderr-1462415.~undo-tree~.gz...done
Wrote /tmp/.straight-stderr-1462415.~undo-tree~.gz
compressing .straight-stderr-1462415.~undo-tree~.gz...done
Wrote /tmp/.straight-stderr-1462415.~undo-tree~.gz
[...Above 2 lines repeat about 14 times...]
Processing repository "rainbow-mode"...done
Processing repository "nix-mode"...
compressing .straight-stderr-1462415.~undo-tree~.gz...done
Wrote /tmp/.straight-stderr-1462415.~undo-tree~.gz
[...14 times...]
Processing repository "nix-mode"...done
Processing repository "echo-bar.el"...
compressing .straight-stderr-1462415.~undo-tree~.gz...done
Wrote /tmp/.straight-stderr-1462415.~undo-tree~.gz
[...etc...]
```

Obviously, `undo-tree` is not relevant when straight is trying to read its stderr file after each process call. At first I pursued ways to prevent undo-tree from activating on this file. That seems harder than I expected – something like this was apparently not enough:
```elisp
  (add-to-list 'auto-mode-alist (cons "straight-stderr-" #'special-mode))
  (add-to-list 'undo-tree-incompatible-major-modes #'special-mode)
```

I thought about hacking `undo-tree` so it can prevent turning on by filename regexp and not just major-mode. But when I read the tips about `find-file-noselect` it seems to me that hacking straight as shown here is the Right Thing™ instead.  Thanks!
