### PR TITLE
Add initial logging framework

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -565,18 +565,24 @@ accident."
       (save-excursion
         (goto-char (point-max))
         (let ((inhibit-read-only t)
-              (args (mapcar
-                     (lambda (arg)
-                       (if (and (listp arg)
-                                (functionp arg))
-                           (funcall arg)
-                         arg))
-                     args)))
+              (body nil))
+          (condition-case err
+              (let ((args (mapcar
+                           (lambda (arg)
+                             (if (and (listp arg)
+                                      (functionp arg))
+                                 (funcall arg)
+                               arg))
+                           args)))
+                (setq body (apply #'format message args)))
+            (error (setq body (format "got error formatting log line %S: %s"
+                                      message
+                                      (error-message-string err)))))
           (insert
            (format
             "%s <%S>: %s\n"
             (format-time-string "%Y-%m-%d %H:%M:%S.%3N" (current-time))
-            category (apply #'format message args))))))))
+            category body)))))))
 
 ;;;;; Buffers
 

--- a/straight.el
+++ b/straight.el
@@ -575,7 +575,7 @@ accident."
                                arg))
                            args)))
                 (setq body (apply #'format message args)))
-            (error (setq body (format "got error formatting log line %S: %s"
+            (error (setq body (format "Got error formatting log line %S: %s"
                                       message
                                       (error-message-string err)))))
           (insert


### PR DESCRIPTION
@progfolio We don't have good tools for responding to questions like https://github.com/radian-software/straight.el/issues/1079, where it's unclear whether there might be a bug, or just a configuration error, or some combination of the two. I've created a lightweight logging framework that can optionally produce additional diagnostic information about both Emacs initialization and user actions. We can add to it over time whenever we have a question we need answered by a reporter. This should assist in troubleshooting bug reports where the issue cannot be reproduced on our end (and even when reproduction is possible, it's usually slow/a pain).

What do you think?