### PR TITLE
Fix two issues that were breaking fs watcher

### DIFF
--- a/watcher/setup.py
+++ b/watcher/setup.py
@@ -10,4 +10,7 @@ setup(
     name="straight-watcher",
     url="https://github.com/radian-software/straight.el",
     version="1.0-dev",
+    # Must be specified explicitly from setuptools>=61
+    # https://github.com/pypa/setuptools/issues/4013
+    py_modules=["straight_watch", "straight_watch_callback"],
 )

--- a/watcher/straight_watch.py
+++ b/watcher/straight_watch.py
@@ -47,7 +47,9 @@ def write_process_data(pid_file):
 def start_watch(repos_dir, modified_dir):
     callback_cmd = [CALLBACK_SCRIPT, repos_dir, modified_dir]
     callback_sh = " ".join(map(shlex.quote, callback_cmd))
-    cmd = ["watchexec", "--no-vcs-ignore", "-p", "-d", "100", callback_sh]
+    # Use --debounce explicitly as some versions of watchexec do not support -d
+    # https://github.com/watchexec/watchexec/pull/513#issuecomment-1683304057
+    cmd = ["watchexec", "--no-vcs-ignore", "-p", "--debounce", "100", callback_sh]
     cmd_sh = " ".join(map(shlex.quote, cmd))
     print("$ " + cmd_sh, file=sys.stderr)
     subprocess.run(cmd, cwd=repos_dir, check=True)


### PR DESCRIPTION
We also _really_ need to detect when the fs watcher is not working, and reinstall / alert the user. That is going to be my second highest priority probably, after adding better logging.