### PR TITLE
Fix modification detection on merge

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -2444,7 +2444,7 @@ confirmation by reset, so this function should only be run after
        ;; Auto fast-forward when tracking branch is behind upstream.
        ((and left-is-ancestor straight-vc-git-auto-fast-forward)
         (straight--process-output "git" "merge" "--ff-only" right-ref)
-        t)
+        nil)
        (t (straight-vc-git--reconcile-interactively local-repo status))))))
 
 (cl-defun straight-vc-git--merge-from-remote-raw


### PR DESCRIPTION
Fixes #1079

The convention of all the vc-git functions is that they return nil if they did something (which means we should double-check to make sure everything else is still as we expect, and register a repo modification).

Looks like the correct return value got lost in a refactor, understandable since I don't know that I documented this rather critical convention.
