### PR TITLE
[#1118] More logs on failed bootstrap

### DIFF
--- a/install.el
+++ b/install.el
@@ -261,6 +261,8 @@
                       nil '(t t) nil
                       "--batch" "--no-window-system" "--quick"
                       "--load" temp-file))
-            (error "straight.el bootstrap failed: %s" (buffer-string)))))))
+            (message "straight.el bootstrap failed: %s" (buffer-string))
+            (error
+             "straight.el bootstrap failed, see prior output for logs"))))))
 
   (message "Bootstrapping straight.el...done"))

--- a/install.el
+++ b/install.el
@@ -244,25 +244,30 @@
       (let ((temp-file (make-temp-file "straight.el~")))
         (write-region nil nil temp-file nil 'silent)
         (with-temp-buffer
-          (unless (= 0
-                     (call-process
-                      ;; Taken with love from package `restart-emacs'.
-                      (let ((emacs-binary-path
-                             (expand-file-name
-                              invocation-name invocation-directory))
-                            (runemacs-binary-path
-                             (when (straight--windows-os-p)
-                               (expand-file-name
-                                "runemacs.exe" invocation-directory))))
-                        (if (and runemacs-binary-path
-                                 (file-exists-p runemacs-binary-path))
-                            runemacs-binary-path
-                          emacs-binary-path))
-                      nil '(t t) nil
-                      "--batch" "--no-window-system" "--quick"
-                      "--load" temp-file))
-            (message "straight.el bootstrap failed: %s" (buffer-string))
-            (error
-             "straight.el bootstrap failed, see prior output for logs"))))))
+          (let ((exit-status
+                 (call-process
+                  ;; Taken with love from package `restart-emacs'.
+                  (let ((emacs-binary-path
+                         (expand-file-name
+                          invocation-name invocation-directory))
+                        (runemacs-binary-path
+                         (when (straight--windows-os-p)
+                           (expand-file-name
+                            "runemacs.exe" invocation-directory))))
+                    (if (and runemacs-binary-path
+                             (file-exists-p runemacs-binary-path))
+                        runemacs-binary-path
+                      emacs-binary-path))
+                  nil '(t t) nil
+                  "--batch" "--no-window-system" "--quick"
+                  "--load" temp-file)))
+            (unless (= 0 exit-status)
+              (message
+               (concat
+                "straight.el bootstrap failed with status %s, "
+                "subprocess logs follow:\n------%s\n------")
+               exit-status
+               (buffer-string))
+              (error "straight.el bootstrap failed, see *Messages*")))))))
 
   (message "Bootstrapping straight.el...done"))


### PR DESCRIPTION
To debug issues like https://github.com/radian-software/straight.el/issues/1118#issuecomment-1730532644 we need better logs when the bootstrap process failed. Just getting a truncated stacktrace that says the exit status was nonzero is rather useless. Let's additionally print a standard `message`, which won't get truncated.

I tested that when pointing the installation snippet at this branch, bootstrap still works. I also created a separate branch `rr-bootstrap-more-logs-testing` with the following diff on top of this PR:

```diff
diff --git a/install.el b/install.el
index f256479..5ed0051 100644
--- a/install.el
+++ b/install.el
@@ -260,7 +260,9 @@
                       emacs-binary-path))
                   nil '(t t) nil
                   "--batch" "--no-window-system" "--quick"
-                  "--load" temp-file)))
+                  "--load" temp-file
+                  "--eval" "(message \"Something bad happening here\")"
+                  "--eval" "(shell-command-to-string (format \"kill %s\" (emacs-pid)))")))
             (unless (= 0 exit-status)
               (message
                (concat
```

When pointing the installation snippet at that branch, I get this on startup:

```
Debugger entered--Lisp error: (error "straight.el bootstrap failed, see *Messages*")
  error("straight.el bootstrap failed, see *Messages*")
  (if (= 0 exit-status) nil (message (concat "straight.el bootstrap failed with status %s, " "subprocess logs follow:\n------%s\n------") exit-status (buffer-string)) (error "straight.el bo$
  (let ((exit-status (call-process (let ((emacs-binary-path (expand-file-name invocation-name invocation-directory)) (runemacs-binary-path (if ... ...))) (if (and runemacs-binary-path (file$
  (progn (let ((exit-status (call-process (let ((emacs-binary-path ...) (runemacs-binary-path ...)) (if (and runemacs-binary-path ...) runemacs-binary-path emacs-binary-path)) nil '(t t) ni$
  (unwind-protect (progn (let ((exit-status (call-process (let (... ...) (if ... runemacs-binary-path emacs-binary-path)) nil '(t t) nil "--batch" "--no-window-system" "--quick" "--load" te$
  (save-current-buffer (set-buffer temp-buffer) (unwind-protect (progn (let ((exit-status (call-process (let ... ...) nil '... nil "--batch" "--no-window-system" "--quick" "--load" temp-fil$
  (let ((temp-buffer (generate-new-buffer " *temp*" t))) (save-current-buffer (set-buffer temp-buffer) (unwind-protect (progn (let ((exit-status (call-process ... nil ... nil "--batch" "--n$
  (let ((temp-file (make-temp-file "straight.el~"))) (write-region nil nil temp-file nil 'silent) (let ((temp-buffer (generate-new-buffer " *temp*" t))) (save-current-buffer (set-buffer tem$
  (save-current-buffer (set-buffer (url-retrieve-synchronously (format (concat "https://raw.githubusercontent.com/" "radian-software/straight.el/install/%s/straight.el") (substring (symbol-$
  (let ((version nil) (straight-profiles (if (boundp 'straight-profiles) straight-profiles '((nil . "default.el")))) (straight-install-dir (or (and (boundp 'straight-base-dir) straight-base$
  (progn (message "Bootstrapping straight.el...") (let ((min-version "25.1")) (if (version< emacs-version min-version) (progn (error (concat "straight.el requires at least Emacs %s, " "but $
  elisp--eval-last-sexp(t)
  eval-last-sexp(t)
  eval-print-last-sexp()
  (save-current-buffer (set-buffer (url-retrieve-synchronously "https://raw.githubusercontent.com/radian-software/..." 'silent 'inhibit-cookies)) (goto-char (point-max)) (eval-print-last-se$
  (if (file-exists-p bootstrap-file) nil (save-current-buffer (set-buffer (url-retrieve-synchronously "https://raw.githubusercontent.com/radian-software/..." 'silent 'inhibit-cookies)) (got$
  (let ((bootstrap-file (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory)) (bootstrap-version 6)) (if (file-exists-p bootstrap-file) nil (save-current-buffer$
  load-with-code-conversion("/home/raxod502/files/temp/straight1122/init.el" "/home/raxod502/files/temp/straight1122/init.el" t t)
  load("/home/raxod502/files/temp/straight1122/init.el" noerror nomessage)
  (cond ((and (not after-init-time) radian--init-file-loaded-p)) (alternate-user-emacs-directory (setq alternate-user-emacs-directory (file-name-as-directory alternate-user-emacs-directory)$
  (let ((alternate-user-emacs-directory (getenv "USER_EMACS_DIRECTORY"))) (defvar radian--init-file-loaded-p nil "Non-nil if the init-file has already been loaded.\n...") (cond ((and (not a$
  load-with-code-conversion("/home/raxod502/.emacs.d/init.el" "/home/raxod502/.emacs.d/init.el" t t)
  load("/home/raxod502/.emacs.d/init" noerror nomessage)
  startup--load-user-init-file(#f(compiled-function () #<bytecode 0x1556a9eceb05767e>) #f(compiled-function () #<bytecode -0x1f3c686ddc0ca9b5>) t)
  command-line()
  normal-top-level()
```

And if I check `*Messages*`, then:

```
Bootstrapping straight.el...
straight.el bootstrap failed with status 15, subprocess logs follow:
------
Something bad happening here
Cloning straight.el...
Cloning straight.el...done

------
Entering debugger...
```

Not perfect, but at least better than what we have now. Does that look safe to you @progfolio?