### PR TITLE
[#1120] Respect straight-base-dir in bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,11 @@ First, place the following bootstrap code in your init-file:
 ```emacs-lisp
 (defvar bootstrap-version)
 (let ((bootstrap-file
-       (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))
-      (bootstrap-version 6))
+       (expand-file-name
+        "straight/repos/straight.el/bootstrap.el"
+        (or (bound-and-true-p straight-base-dir)
+            user-emacs-directory)))
+      (bootstrap-version 7))
   (unless (file-exists-p bootstrap-file)
     (with-current-buffer
         (url-retrieve-synchronously
@@ -1421,8 +1424,11 @@ care of all these details for you:
 ```emacs-lisp
 (defvar bootstrap-version)
 (let ((bootstrap-file
-       (expand-file-name "straight/repos/straight.el/bootstrap.el" user-emacs-directory))
-      (bootstrap-version 6))
+       (expand-file-name
+        "straight/repos/straight.el/bootstrap.el"
+        (or (bound-and-true-p straight-base-dir)
+            user-emacs-directory)))
+      (bootstrap-version 7))
   (unless (file-exists-p bootstrap-file)
     (with-current-buffer
         (url-retrieve-synchronously

--- a/benchmark/straight-bench.el
+++ b/benchmark/straight-bench.el
@@ -246,8 +246,9 @@ SHALLOW nil means use the default behavior of full clones."
              (let ((bootstrap-file
                     (expand-file-name
                      "straight/repos/straight.el/bootstrap.el"
-                     user-emacs-directory))
-                   (bootstrap-version 6))
+                     (or (bound-and-true-p straight-base-dir)
+                         user-emacs-directory)))
+                   (bootstrap-version 7))
                (unless (file-exists-p bootstrap-file)
                  (with-current-buffer
                      (url-retrieve-synchronously

--- a/straight.el
+++ b/straight.el
@@ -6985,9 +6985,11 @@ Interactively, or when MESSAGE is non-nil, show in the echo area."
 (defvar straight-bug-report--bootstrap
   '((defvar bootstrap-version)
     (let ((bootstrap-file
-           (expand-file-name "straight/repos/straight.el/bootstrap.el"
-                             user-emacs-directory))
-          (bootstrap-version 6))
+           (expand-file-name
+            "straight/repos/straight.el/bootstrap.el"
+            (or (bound-and-true-p straight-base-dir)
+                user-emacs-directory)))
+          (bootstrap-version 7))
       (unless (file-exists-p bootstrap-file)
         (with-current-buffer
             (url-retrieve-synchronously


### PR DESCRIPTION
Pretty self explanatory. If the user modifies `straight-base-dir` then of course they must modify the bootstrap snippet to use that directory instead of `user-emacs-directory`. However, we might as well do it automatically for them, instead of requiring this extra step.