### PR TITLE
[#964] Allow installing seq from GNU ELPA

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -3323,8 +3323,7 @@ does such a good job of discouraging contributions anyway."
 (defcustom straight-recipes-gnu-elpa-ignored-packages
   '(cl-generic
     cl-lib
-    nadvice
-    seq)
+    nadvice)
   "Packages from GNU ELPA that we should pretend don't exist.
 Such packages would break things if they were installed. For
 example, the `cl-lib' package from GNU ELPA is not the


### PR DESCRIPTION
I think this is the right solution to https://github.com/radian-software/straight.el/issues/964 - per Jonas, the version of `seq.el` on GNU ELPA is newer than what is in Emacs now, and it is a legit package that people need to be able to install as a dependency. I'm not sure why this was in the list to begin with, maybe things were different in the past.