### PR TITLE
Set print-symbols-bare to t while saving the build cache

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -4260,11 +4260,17 @@ The name of the cache file is stored in
   (straight--log 'modification-detection "Saving build cache")
   (unless straight-safe-mode
     (with-temp-buffer
-      ;; Prevent mangling of the form being printed in the case that
-      ;; this function was called by an `eval-expression' invocation
-      ;; of `straight-use-package'.
-      (let ((print-level nil)
-            (print-length nil))
+      (let (;; Prevent mangling of the form being printed in the case that
+            ;; this function was called by an `eval-expression' invocation
+            ;; of `straight-use-package'.
+            (print-level nil)
+            (print-length nil)
+            ;; Print symbols with attached positions, which can occur
+            ;; during byte compilation, as bare symbols so they can be
+            ;; read when loading the cache.
+            (print-symbols-bare t))
+        ;; Stop the byte-compiler from complaining about unused binding.
+        (ignore print-symbols-bare)
         ;; The version of the build cache.
         (print straight--build-cache-version (current-buffer))
         ;; Record the current Emacs version. If a different version of


### PR DESCRIPTION
This fixes a bug where recipes may contain symbols with positions, which have a printed representation but no read syntax, causing the subsequent load of the build cache to fail. Symbols with positions may be generated during the execution of the byte compiler.

The fix is to bind `print-symbols-bare` to `t` during the printing of the build cache in `straight--save-build-cache`. This strips the attached positions from the symbols. The attached positions are not used by `straight.el` in any way, so the build cache remains valid when loaded. The distinction between bare symbols and symbols with positions is only relevant here (during build cache save), since `symbols-with-pos-enabled` is bound to `t` during the execution of the byte compiler, causing symbols with positions to transparently behave as their contained bare symbols.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/radian-software/contributor-guide>

Please create pull requests against the develop branch only!

-->
