### PR TITLE
[#1167] Support MELPA :rename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ for_compile := straight.el bootstrap.el install.el straight-x.el	\
 for_checkdoc := straight.el
 for_longlines := $(wildcard *.el *.md *.yml benchmark/*.el	\
 	scripts/*.bash) Makefile
-for_checkindent := $(wildcard *.el benchmark/*.el)
+for_checkindent := $(wildcard *.el benchmark/*.el tests/*.el)
 
 # excludes benchmarking, smoke and unit tests
 .PHONY: all
@@ -62,6 +62,7 @@ checkindent: ## Ensure that indentation is correct
 	        --eval "(setq inhibit-message t)" \
 	        --eval "(load (expand-file-name \"indent.el\"  ) nil t)" \
 	        --eval "(load (expand-file-name \"straight.el\") nil t)" \
+		--eval "(load (expand-file-name \"tests/straight-test.el\") nil t)" \
 	        --eval "(find-file \"$$file\")" \
 	        --eval "(indent-region (point-min) (point-max))" \
 	        --eval "(write-file \"$$tmpdir/$$tmpfile\")"; \

--- a/straight.el
+++ b/straight.el
@@ -3288,8 +3288,7 @@ return nil."
                 (setq files
                       (mapcar
                        (lambda (entry)
-                         (when (and (listp entry)
-                                    (eq (car entry) :rename))
+                         (when (eq (car-safe entry) :rename)
                            (setq entry (cons (nth 1 entry) (nth 2 entry))))
                          entry)
                        files))

--- a/tests/mocks/.emacs.d/straight/repos/melpa/recipes/bbdb
+++ b/tests/mocks/.emacs.d/straight/repos/melpa/recipes/bbdb
@@ -1,0 +1,4 @@
+(bbdb
+ :fetcher git
+ :url "https://git.savannah.nongnu.org/git/bbdb.git"
+ :files (:defaults (:rename "lisp/bbdb-site.el.in" "bbdb-site.el")))

--- a/tests/mocks/.emacs.d/straight/repos/melpa/recipes/ditz-mode
+++ b/tests/mocks/.emacs.d/straight/repos/melpa/recipes/ditz-mode
@@ -1,0 +1,1 @@
+(ditz-mode :fetcher hg :url "https://hg.sr.ht/~zondo/ditz-mode")

--- a/tests/mocks/.emacs.d/straight/repos/melpa/recipes/git-link
+++ b/tests/mocks/.emacs.d/straight/repos/melpa/recipes/git-link
@@ -1,0 +1,3 @@
+(git-link
+ :fetcher github
+ :repo "sshaw/git-link")

--- a/tests/mocks/.emacs.d/straight/repos/melpa/recipes/gitlab
+++ b/tests/mocks/.emacs.d/straight/repos/melpa/recipes/gitlab
@@ -1,0 +1,4 @@
+(gitlab
+ :fetcher github
+ :repo "nlamirault/emacs-gitlab"
+ :files ("gitlab*.el"))

--- a/tests/straight-test.el
+++ b/tests/straight-test.el
@@ -18,7 +18,7 @@ for BINDINGS."
         (list template)
       (let ((unbound (mod (length bindings) (length vars))))
         (unless (zerop unbound)
-          (error "Unven binding list: %S" (last bindings unbound)))
+          (error "Uneven binding list: %S" (last bindings unbound)))
         (let ((body nil)
               (bindings
                (eval
@@ -207,10 +207,10 @@ return nil."
 
 (straight-deftest straight--build-steps ()
   (let* ((defaults
-          (mapcar (lambda (sym)
-                    (intern (string-remove-prefix "straight-disable-"
-                                                  (symbol-name sym))))
-                  straight--build-default-steps))
+           (mapcar (lambda (sym)
+                     (intern (string-remove-prefix "straight-disable-"
+                                                   (symbol-name sym))))
+                   straight--build-default-steps))
          (straight-disable-info
           (member 'info           ,disabled))
          (straight-disable-compile
@@ -308,14 +308,14 @@ return nil."
 
 (straight-deftest straight--ensure-blank-lines ()
   (cl-flet ((buffer-with-point-at (s n)
-              (with-temp-buffer
-                (insert s)
-                (goto-char (point-min))
-                (when (search-forward "|" nil t)
-                  (delete-region (match-beginning 0)
-                                 (match-end 0)))
-                (straight--ensure-blank-lines n)
-                (buffer-string))))
+                                  (with-temp-buffer
+                                    (insert s)
+                                    (goto-char (point-min))
+                                    (when (search-forward "|" nil t)
+                                      (delete-region (match-beginning 0)
+                                                     (match-end 0)))
+                                    (straight--ensure-blank-lines n)
+                                    (buffer-string))))
     (should (equal ,buffer-string (buffer-with-point-at ,string ,n))))
   (string n buffer-string)
   "|beginning-of-buffer" 1 "beginning-of-buffer"
@@ -609,6 +609,27 @@ return nil."
                      (straight-test-trim-to-mocks
                       (straight--watcher-file ,in)))))
   (in) "test.el")
+
+(straight-deftest straight-recipes-melpa-retrieve ()
+  (let ((straight-base-dir straight-test-mock-user-emacs-dir))
+    (let ((default-directory (straight--repos-dir "melpa")))
+      (should (equal (straight-recipes-melpa-retrieve ,in)
+                     ,out))))
+  (in out)
+  ;; package that isn't in our mocks
+  'doesnotexist nil
+  ;; package that uses :fetcher hg
+  'ditz-mode nil
+  ;; normal package
+  'git-link '(git-link :type git :host github :repo "sshaw/git-link")
+  ;; package with custom :files directive
+  'gitlab '(gitlab :type git :files ("gitlab*.el" "gitlab-pkg.el")
+                   :host github :repo "nlamirault/emacs-gitlab")
+  ;; package that uses :rename keyword
+  'bbdb '(bbdb :type git
+               :files (:defaults
+                       ("lisp/bbdb-site.el.in" . "bbdb-site.el") "bbdb-pkg.el")
+               :repo "https://git.savannah.nongnu.org/git/bbdb.git"))
 
 (provide 'straight-test)
 


### PR DESCRIPTION
Close https://github.com/radian-software/straight.el/issues/1167. Remove the default behavior of renaming `.el.in` files in MELPA recipes as it has been removed upstream. Support `:rename` (which was added to upstream as a replacement) by translating it in the MELPA recipe fetcher into the cons-cell style renaming that was already supported in `straight.el`.

Add tests for the modified function, and mock data to support the tests. Change the indentation in the testing code to what Emacs wanted it to be by default, and add linting for the indentation in this file. (The changes are not entirely improvements, but if we want better indentation, we should make sure Emacs is configured to do it properly in this project rather than having it be a personal choice for each contributor.)