### PR TITLE
Upgrade actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         emacs_version: [25, 26, 27, 28]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: CI
         env:
           VERSION: ${{ matrix.emacs_version }}


### PR DESCRIPTION
Fix the following Github actions warning:

"The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v2. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/"

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/radian-software/contributor-guide>

Please create pull requests against the develop branch only!

-->
