### PR TITLE
update git.sr.ht to sr.ht

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -287,7 +287,7 @@ computes the fork as \"githubUser/fork\"."
 (defcustom straight-hosts '((github "github.com" ".git")
                             (gitlab "gitlab.com" ".git")
                             (codeberg "codeberg.org" ".git")
-                            (sourcehut "git.sr.ht")
+                            (sourcehut "sr.ht")
                             (bitbucket "bitbucket.com" ".git"))
   "Alist containing URI information for hosted forges.
 Each element is of the form: (HOST DOMAIN REPO-SUFFIX).

--- a/tests/straight-test.el
+++ b/tests/straight-test.el
@@ -566,8 +566,8 @@ return nil."
   "git@github.com:user/test.git"       '("user/test" github ssh)
   "https://codeberg.org/user/test.git" '("user/test" codeberg https)
   "git@codeberg.org:user/test.git"     '("user/test" codeberg ssh)
-  "git@git.sr.ht:~user/test"           '("user/test" sourcehut ssh)
-  "https://git.sr.ht/~user/test"       '("user/test" sourcehut https))
+  "git@sr.ht:~user/test"           '("user/test" sourcehut ssh)
+  "https://sr.ht/~user/test"       '("user/test" sourcehut https))
 
 (straight-deftest straight-vc-git--encode-url ()
   (let ((straight-vc-git-default-protocol 'https))


### PR DESCRIPTION
currently we get a 403 when using `:host sourcehut`
