### PR TITLE
feat: respect absolute path for straight-profiles for bootstrap install

### DIFF
--- a/install.el
+++ b/install.el
@@ -118,9 +118,10 @@
     ;; the recipe specification, and forgot to update which repository
     ;; their init-file downloaded install.el from).
     (dolist (lockfile-name (mapcar #'cdr straight-profiles))
-      (let ((lockfile-path (concat straight-install-dir
-                                   "straight/versions/"
-                                   lockfile-name)))
+      (let ((lockfile-path
+             (expand-file-name
+              lockfile-name
+              (concat straight-install-dir "straight/versions"))))
         (when (file-exists-p lockfile-path)
           (condition-case nil
               (with-temp-buffer


### PR DESCRIPTION
Currently the bootstrap assumes that the lockfile path must be relative file relative to `straight-base-dir/striahgt/versions`,

however, some users might prefer to manage their lockfile in their version controlled dotfiles repo (`~/.config/emacs/straight/versions`), and manage the straight data under XDG spec, aka `~/.local/share/emacs/`.

This patch updates the bootstrap script so that the user's lockfile file path is an absolute path, it will be used