### PR TITLE
added straight-x-open-straight-package-readme function

### DIFF
--- a/straight-x.el
+++ b/straight-x.el
@@ -208,6 +208,32 @@ those listed."
   (straight-freeze-versions)
   (straight-x-freeze-pinned-versions))
 
+(defun straight-x-open-straight-package-readme (package-name)
+  "Open the README file of a straight package in read-only mode."
+  (interactive
+   (let* ((repos-dir (expand-file-name "straight/repos/" straight-base-dir))
+          (package-names (if (file-directory-p repos-dir)
+                             (cl-remove-if-not
+                              (lambda (dir)
+                                (seq-some
+                                 (lambda (file)
+                                   (string-match-p "^README\\(?:\\..*\\)?$" file))
+                                 (directory-files (expand-file-name dir repos-dir) nil "^[^.]+")))
+                              (directory-files repos-dir nil "^[^.]+"))
+                           (error "Repositories directory not found: %s" repos-dir))))
+     (list (completing-read "Enter package name: " package-names nil t))))
+  (let* ((repo-path (expand-file-name package-name (expand-file-name "straight/repos/" straight-base-dir)))
+         (readme-path (seq-some
+                       (lambda (file)
+                         (when (string-match-p "^README\\(?:\\..*\\)?$" file)
+                           (expand-file-name file repo-path)))
+                       (directory-files repo-path))))
+    (if readme-path
+        (let ((buffer (find-file-read-only readme-path)))
+          (message "Opened %s in read-only mode." readme-path)
+          buffer)
+      (message "No README file found for package: %s" package-name))))
+
 
 (provide 'straight-x)
 


### PR DESCRIPTION
Since many packages don't include a manual, accessing a packages README may be necessary at times. This function produces a list of directories in straight/repos that include a README file.  When a package is selected, opens its associated README file in read-only-mode.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/radian-software/contributor-guide>

Please create pull requests against the develop branch only!

-->
