### PR TITLE
[#1184] Update docs for recipe repos list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,6 @@ jobs:
           VERSION: ${{ matrix.emacs_version }}
         run: >-
           make docker
-          CMD="make -k compile checkdoc longlines test smoke"
+          CMD="make compile test smoke checkdoc longlines"
           DOCKER_BASE=ghcr.io/radian-software/emacs-base
           NO_SUDO_DOCKER=1

--- a/README.md
+++ b/README.md
@@ -2478,10 +2478,14 @@ updates: see [#323].
 The recipe repository system is designed to be extended. Firstly, you
 can control which recipe repositories are searched, and in what order
 of precedence, by customizing `straight-recipe-repositories`. The
-default value is:
+default value is defined by the `straight-use-recipes` declarations
+present in the file `bootstrap.el` in the `straight.el` version you
+are using, as customized by the user options you configure in your
+init-file before loading the bootstrap snippet. As of the time of this
+writing, with no custom user options set, that works out to be:
 
 ```emacs-lisp
-(org-elpa melpa gnu-elpa-mirror el-get emacsmirror)
+(org-elpa melpa gnu-elpa-mirror nongnu-elpa el-get emacsmirror-mirror)
 ```
 
 ##### GNU ELPA

--- a/scripts/smoke-test.bash
+++ b/scripts/smoke-test.bash
@@ -4,7 +4,7 @@ set -e
 set -o pipefail
 
 mkdir -p "$HOME/.emacs.d/straight/repos/"
-ln -sf "$PWD" "$HOME/.emacs.d/straight/repos/straight.el"
+ln -sfT "$PWD" "$HOME/.emacs.d/straight/repos/straight.el"
 
 # We need to test with a package that supports Emacs 25.1 here.
 emacs --batch -l "$HOME/.emacs.d/straight/repos/straight.el/bootstrap.el" \


### PR DESCRIPTION
Closes #1184

Also changes CI so that it will stop at the first error, instead of running all tests regardless, which should make error messages easier to read. I re-ordered the steps so that it will likely surface the most useful error first before running less critical linters.

Also fixes a bug affecting Emacs 27 and below which was exposed by an unrelated upstream update to the package we were installing in the smoke test, where unknown major modes in file-local variables caused an error while generating autoloads.
