### PR TITLE
Normalize straight.el indentation on all Emacs versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        emacs_version: [25, 26, 27, 28, 29]
+        emacs_version: [25, 26, 27, 28, 29, 30]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,6 @@ jobs:
           VERSION: ${{ matrix.emacs_version }}
         run: >-
           make docker
-          CMD="make compile test smoke checkdoc longlines"
+          CMD="make compile test smoke checkdoc longlines checkindent"
           DOCKER_BASE=ghcr.io/radian-software/emacs-base
           NO_SUDO_DOCKER=1

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ help: ## Show this message
 		column -t -s'|' >&2
 
 .PHONY: lint
-lint: compile checkdoc longlines toc ## Run all the linters
+lint: compile checkdoc longlines checkindent toc ## Run all the linters
 
 .PHONY: compile
 compile: ## Byte-compile

--- a/benchmark/straight-bench.el
+++ b/benchmark/straight-bench.el
@@ -294,12 +294,14 @@ SHALLOW nil means use the default behavior of full clones."
   "Invoke CALLBACK with no args after mapping FUNC over ITEMS.
 FUNC is an asynchronous function taking a callback of no args and
 one of ITEMS and performing some side effects."
-  (cl-labels ((func-callback
+  ;; Use func name starting with "def" to workaround indentation bug
+  ;; in Emacs 28 and below
+  (cl-labels ((deffunc-callback
                 ()
                 (if items
-                    (funcall func #'func-callback (pop items))
+                    (funcall func #'deffunc-callback (pop items))
                   (funcall callback))))
-    (func-callback)))
+    (deffunc-callback)))
 
 (defun straight-bench-run-plan (callback)
   "Run all the tests in `straight-bench-test-plan'.

--- a/benchmark/straight-bench.el
+++ b/benchmark/straight-bench.el
@@ -295,10 +295,10 @@ SHALLOW nil means use the default behavior of full clones."
 FUNC is an asynchronous function taking a callback of no args and
 one of ITEMS and performing some side effects."
   (cl-labels ((func-callback
-               ()
-               (if items
-                   (funcall func #'func-callback (pop items))
-                 (funcall callback))))
+                ()
+                (if items
+                    (funcall func #'func-callback (pop items))
+                  (funcall callback))))
     (func-callback)))
 
 (defun straight-bench-run-plan (callback)

--- a/indent.el
+++ b/indent.el
@@ -4,7 +4,41 @@
 ;; functions.
 ;;
 ;; Generally speaking, we use indentation rules from Emacs 30 to
-;; indent the straight.el source code.
+;; indent the straight.el source code. There are a few tricks to make
+;; this work:
+;;
+;; * Avoid let-binding a variable whose name begins with `def'. Doing
+;; so produces incorrect indentation in Emacs 28 and below, due to an
+;; overly broad heuristic in the lisp-indent code. If binding a
+;; lexical variable, try renaming the variable to something else. If
+;; binding a dynamic variable like `default-directory', the
+;; indentation is fine as long as the binding fits on a single line.
+;; To bind the variable to a longer value, try binding the value to a
+;; temporary name first, and then the variable to the temporary name
+;; on a single line.
+;;
+;; * In `cl-labels' and `cl-flet', make the local functions use names
+;; which begin with `def'. This will make them indent correctly in
+;; Emasc 28 and below, as a helpful side effect of the bug mentioned
+;; above. In later versions these forms are always indented correctly.
+;;
+;; * When writing a data list (i.e., a list that is not a function
+;; call) split over multiple lines, put a space between the opening
+;; paren and the first element. There is code in Emacs 28 and above to
+;; ensure that this convention forces the list to be indented the way
+;; you would expect (i.e. with all elements at the same indentation).
+;; In this file we backport that logic to Emacs 27 and below. Note
+;; that you have to put the first element on the same line as the
+;; opening paren for this to work, as later versions can do the same
+;; when the first line has a comment instead of the first elements,
+;; but earlier versions can't.
+;;
+;; * When using `define-key', use instead `straight--define-key',
+;; which is an alias whose indentation remains the same across Emacs
+;; versions, unlike `define-key' which changed in Emacs 29 due to the
+;; heuristic change mentioned above. (Avoid `keymap-set', until we
+;; drop support for Emacs 28 and prior, where that function doesn't
+;; exist yet.)
 
 (put #'if-let 'lisp-indent-function 2)
 (put #'when-let 'lisp-indent-function 1)

--- a/indent.el
+++ b/indent.el
@@ -11,3 +11,162 @@
 
 (put #'use-package-only-one 'lisp-indent-function 'defun)
 (put #'use-package-process-keywords 'lisp-indent-function 'defun)
+
+(when (version< emacs-version "28")
+
+  (defun straight--calculate-lisp-indent-emacs28 (&optional parse-start)
+    "Return appropriate indentation for current line as Lisp code.
+In usual case returns an integer: the column to indent to.
+If the value is nil, that means don't change the indentation
+because the line starts inside a string.
+
+PARSE-START may be a buffer position to start parsing from, or a
+parse state as returned by calling `parse-partial-sexp' up to the
+beginning of the current line.
+
+The value can also be a list of the form (COLUMN CONTAINING-SEXP-START).
+This means that following lines at the same level of indentation
+should not necessarily be indented the same as this line.
+Then COLUMN is the column to indent to, and CONTAINING-SEXP-START
+is the buffer position of the start of the containing expression."
+    (save-excursion
+      (beginning-of-line)
+      (let ((indent-point (point))
+            state
+            ;; setting this to a number inhibits calling hook
+            (desired-indent nil)
+            (retry t)
+            whitespace-after-open-paren
+            calculate-lisp-indent-last-sexp containing-sexp)
+        (cond ((or (markerp parse-start) (integerp parse-start))
+               (goto-char parse-start))
+              ((null parse-start) (beginning-of-defun))
+              (t (setq state parse-start)))
+        (unless state
+          ;; Find outermost containing sexp
+          (while (< (point) indent-point)
+            (setq state (parse-partial-sexp (point) indent-point 0))))
+        ;; Find innermost containing sexp
+        (while (and retry
+		    state
+                    (> (elt state 0) 0))
+          (setq retry nil)
+          (setq calculate-lisp-indent-last-sexp (elt state 2))
+          (setq containing-sexp (elt state 1))
+          ;; Position following last unclosed open.
+          (goto-char (1+ containing-sexp))
+          ;; Is there a complete sexp since then?
+          (if (and calculate-lisp-indent-last-sexp
+		   (> calculate-lisp-indent-last-sexp (point)))
+              ;; Yes, but is there a containing sexp after that?
+              (let ((peek (parse-partial-sexp calculate-lisp-indent-last-sexp
+					      indent-point 0)))
+                (if (setq retry (car (cdr peek))) (setq state peek)))))
+        (if retry
+            nil
+          ;; Innermost containing sexp found
+          (goto-char (1+ containing-sexp))
+          (setq whitespace-after-open-paren (looking-at (rx whitespace)))
+          (if (not calculate-lisp-indent-last-sexp)
+	      ;; indent-point immediately follows open paren.
+	      ;; Don't call hook.
+              (setq desired-indent (current-column))
+	    ;; Find the start of first element of containing sexp.
+	    (parse-partial-sexp (point) calculate-lisp-indent-last-sexp 0 t)
+	    (cond ((looking-at "\\s(")
+		   ;; First element of containing sexp is a list.
+		   ;; Indent under that list.
+		   )
+		  ((> (save-excursion (forward-line 1) (point))
+		      calculate-lisp-indent-last-sexp)
+		   ;; This is the first line to start within the containing sexp.
+		   ;; It's almost certainly a function call.
+		   (if (or (= (point) calculate-lisp-indent-last-sexp)
+                           whitespace-after-open-paren)
+		       ;; Containing sexp has nothing before this line
+		       ;; except the first element, or the first element is
+                       ;; preceded by whitespace.  Indent under that element.
+		       nil
+		     ;; Skip the first element, find start of second (the first
+		     ;; argument of the function call) and indent under.
+		     (progn (forward-sexp 1)
+			    (parse-partial-sexp (point)
+					        calculate-lisp-indent-last-sexp
+					        0 t)))
+		   (backward-prefix-chars))
+		  (t
+		   ;; Indent beneath first sexp on same line as
+		   ;; `calculate-lisp-indent-last-sexp'.  Again, it's
+		   ;; almost certainly a function call.
+		   (goto-char calculate-lisp-indent-last-sexp)
+		   (beginning-of-line)
+		   (parse-partial-sexp (point) calculate-lisp-indent-last-sexp
+				       0 t)
+		   (backward-prefix-chars)))))
+        ;; Point is at the point to indent under unless we are inside a string.
+        ;; Call indentation hook except when overridden by lisp-indent-offset
+        ;; or if the desired indentation has already been computed.
+        (let ((normal-indent (current-column)))
+          (cond ((elt state 3)
+                 ;; Inside a string, don't change indentation.
+	         nil)
+                ((and (integerp lisp-indent-offset) containing-sexp)
+                 ;; Indent by constant offset
+                 (goto-char containing-sexp)
+                 (+ (current-column) lisp-indent-offset))
+                ;; in this case calculate-lisp-indent-last-sexp is not nil
+                (calculate-lisp-indent-last-sexp
+                 (or
+                  ;; try to align the parameters of a known function
+                  (and lisp-indent-function
+                       (not retry)
+                       (funcall lisp-indent-function indent-point state))
+                  ;; If the function has no special alignment
+		  ;; or it does not apply to this argument,
+		  ;; try to align a constant-symbol under the last
+                  ;; preceding constant symbol, if there is such one of
+                  ;; the last 2 preceding symbols, in the previous
+                  ;; uncommented line.
+                  (and (save-excursion
+                         (goto-char indent-point)
+                         (skip-chars-forward " \t")
+                         (looking-at ":"))
+                       ;; The last sexp may not be at the indentation
+                       ;; where it begins, so find that one, instead.
+                       (save-excursion
+                         (goto-char calculate-lisp-indent-last-sexp)
+		         ;; Handle prefix characters and whitespace
+		         ;; following an open paren.  (Bug#1012)
+                         (backward-prefix-chars)
+                         (while (not (or (looking-back "^[ \t]*\\|([ \t]+"
+                                                       (line-beginning-position))
+                                         (and containing-sexp
+                                              (>= (1+ containing-sexp) (point)))))
+                           (forward-sexp -1)
+                           (backward-prefix-chars))
+                         (setq calculate-lisp-indent-last-sexp (point)))
+                       (> calculate-lisp-indent-last-sexp
+                          (save-excursion
+                            (goto-char (1+ containing-sexp))
+                            (parse-partial-sexp (point) calculate-lisp-indent-last-sexp 0 t)
+                            (point)))
+                       (let ((parse-sexp-ignore-comments t)
+                             indent)
+                         (goto-char calculate-lisp-indent-last-sexp)
+                         (or (and (looking-at ":")
+                                  (setq indent (current-column)))
+                             (and (< (line-beginning-position)
+                                     (prog2 (backward-sexp) (point)))
+                                  (looking-at ":")
+                                  (setq indent (current-column))))
+                         indent))
+                  ;; another symbols or constants not preceded by a constant
+                  ;; as defined above.
+                  normal-indent))
+                ;; in this case calculate-lisp-indent-last-sexp is nil
+                (desired-indent)
+                (t
+                 normal-indent))))))
+
+  (advice-add #'calculate-lisp-indent :override
+              #'straight--calculate-lisp-indent-emacs28))

--- a/indent.el
+++ b/indent.el
@@ -1,5 +1,10 @@
 ;; You can load this file to make sure that forms from other packages
-;; are indented correctly.
+;; are indented correctly. It should cause the indentation to be the
+;; same as if you had actually loaded the packages that define these
+;; functions.
+;;
+;; Generally speaking, we use indentation rules from Emacs 30 to
+;; indent the straight.el source code.
 
 (put #'if-let 'lisp-indent-function 2)
 (put #'when-let 'lisp-indent-function 1)

--- a/straight.el
+++ b/straight.el
@@ -3303,24 +3303,24 @@ Otherwise return nil."
     ('org-contrib
      (list package
            :type 'git
-           :includes '(;; Intentionally blank for indentation.
-                       ob-csharp ob-eukleides
-                       ob-fomus ob-julia ob-mathomatic ob-oz
-                       ob-stata
-                       ob-tcl ob-vbnet ol-bookmark ol-elisp-symbol ol-git-link
-                       ol-man ol-mew ol-vm ol-wl org-annotate-file
-                       org-bibtex-extras
-                       org-checklist org-choose org-collector
-                       org-contribdir org-depend org-effectiveness org-eldoc
-                       org-eval org-eval-light org-expiry
-                       org-interactive-query org-invoice org-learn org-license
-                       org-mac-iCal org-mairix
-                       org-panel org-registry org-screen
-                       org-screenshot org-secretary org-static-mathjax
-                       org-sudoku orgtbl-sqlinsert org-toc org-track
-                       org-wikinodes ox-bibtex ox-confluence
-                       ox-deck ox-extra ox-freemind ox-groff ox-koma-letter
-                       ox-s5 ox-taskjuggler)
+           ;; Leading space for indentation.
+           :includes '( ob-csharp ob-eukleides
+                        ob-fomus ob-julia ob-mathomatic ob-oz
+                        ob-stata
+                        ob-tcl ob-vbnet ol-bookmark ol-elisp-symbol ol-git-link
+                        ol-man ol-mew ol-vm ol-wl org-annotate-file
+                        org-bibtex-extras
+                        org-checklist org-choose org-collector
+                        org-contribdir org-depend org-effectiveness org-eldoc
+                        org-eval org-eval-light org-expiry
+                        org-interactive-query org-invoice org-learn org-license
+                        org-mac-iCal org-mairix
+                        org-panel org-registry org-screen
+                        org-screenshot org-secretary org-static-mathjax
+                        org-sudoku orgtbl-sqlinsert org-toc org-track
+                        org-wikinodes ox-bibtex ox-confluence
+                        ox-deck ox-extra ox-freemind ox-groff ox-koma-letter
+                        ox-s5 ox-taskjuggler)
            :repo "https://git.sr.ht/~bzg/org-contrib"
            :files '(:defaults "lisp/*.el")))))
 

--- a/straight.el
+++ b/straight.el
@@ -1210,10 +1210,10 @@ regard to keybindings."
                 (format "%s\n %s%s %s" prompt
                         (make-string (- max-length (length key)) ? )
                         key desc)))
-        (define-key keymap (kbd key)
-          (lambda ()
-            (interactive)
-            (apply func args)))))
+        (keymap-set keymap key
+                    (lambda ()
+                      (interactive)
+                      (apply func args)))))
     (setq prompt (concat prompt "\n\n"))
     (let ((max-mini-window-height 1.0)
           (cursor-in-echo-area t))
@@ -3123,13 +3123,13 @@ For example:
         (straight--with-plist recipe
             (local-repo)
           (let ((default-directory
-                  ;; Only change directories if a local repository is
-                  ;; specified. If one is not, then we assume the
-                  ;; recipe repository code does not need to be in any
-                  ;; particular directory.
-                  (if local-repo
-                      (straight--repos-dir local-repo)
-                    default-directory))
+                 ;; Only change directories if a local repository is
+                 ;; specified. If one is not, then we assume the
+                 ;; recipe repository code does not need to be in any
+                 ;; particular directory.
+                 (if local-repo
+                     (straight--repos-dir local-repo)
+                   default-directory))
                 (func (intern (format "straight-recipes-%S-%S"
                                       name method))))
             (apply func args)))))))
@@ -3837,16 +3837,16 @@ for dependency resolution."
               ;; not present in the override and adding them there.
               (let* ((sources (plist-get plist :source))
                      (default
-                       (or
-                        (when-let ((retrieved (straight-recipes-retrieve
-                                               package
-                                               (if (listp sources)
-                                                   sources
-                                                 (list sources)))))
-                          ;; Recipes retrieved from files may be backquoted.
-                          (cdr (if (straight--quoted-form-p retrieved)
-                                   (eval retrieved) retrieved)))
-                        plist))
+                      (or
+                       (when-let ((retrieved (straight-recipes-retrieve
+                                              package
+                                              (if (listp sources)
+                                                  sources
+                                                (list sources)))))
+                         ;; Recipes retrieved from files may be backquoted.
+                         (cdr (if (straight--quoted-form-p retrieved)
+                                  (eval retrieved) retrieved)))
+                       plist))
                      (type (if (plist-member default :type)
                                (plist-get default :type)
                              straight-default-vc))
@@ -4696,7 +4696,7 @@ last time."
                         (setq mtime-or-file
                               (straight--make-mtime last-mtime)))
                       (let* ((default-directory
-                               (straight--repos-dir local-repo))
+                              (straight--repos-dir local-repo))
                              ;; This find(1) command ignores the .git
                              ;; directory, and prints the names of any
                              ;; files or directories with a newer

--- a/straight.el
+++ b/straight.el
@@ -73,6 +73,10 @@
       "Non-nil means calls to ‘message’ are not displayed.
 They are still logged to the *Messages* buffer.")))
 
+;; The indentation of `define-key' changes depending on Emacs version,
+;; define an alias which doesn't.
+(defalias 'straight--define-key #'define-key)
+
 ;;;; Functions from other packages
 
 ;; `comp'
@@ -1210,10 +1214,11 @@ regard to keybindings."
                 (format "%s\n %s%s %s" prompt
                         (make-string (- max-length (length key)) ? )
                         key desc)))
-        (keymap-set keymap key
-                    (lambda ()
-                      (interactive)
-                      (apply func args)))))
+        (straight--define-key
+         keymap (kbd key)
+         (lambda ()
+           (interactive)
+           (apply func args)))))
     (setq prompt (concat prompt "\n\n"))
     (let ((max-mini-window-height 1.0)
           (cursor-in-echo-area t))

--- a/tests/straight-test.el
+++ b/tests/straight-test.el
@@ -307,7 +307,9 @@ return nil."
                  (straight--emacs-path))))
 
 (straight-deftest straight--ensure-blank-lines ()
-  (cl-flet ((buffer-with-point-at (s n)
+  ;; Use func name starting with "def" to workaround indentation bug
+  ;; in Emacs 28 and below
+  (cl-flet ((defbuffer-with-point-at (s n)
               (with-temp-buffer
                 (insert s)
                 (goto-char (point-min))
@@ -316,7 +318,7 @@ return nil."
                                  (match-end 0)))
                 (straight--ensure-blank-lines n)
                 (buffer-string))))
-    (should (equal ,buffer-string (buffer-with-point-at ,string ,n))))
+    (should (equal ,buffer-string (defbuffer-with-point-at ,string ,n))))
   (string n buffer-string)
   "|beginning-of-buffer" 1 "beginning-of-buffer"
   "a|b" 1 "a\nb"

--- a/tests/straight-test.el
+++ b/tests/straight-test.el
@@ -207,10 +207,10 @@ return nil."
 
 (straight-deftest straight--build-steps ()
   (let* ((defaults
-           (mapcar (lambda (sym)
-                     (intern (string-remove-prefix "straight-disable-"
-                                                   (symbol-name sym))))
-                   straight--build-default-steps))
+          (mapcar (lambda (sym)
+                    (intern (string-remove-prefix "straight-disable-"
+                                                  (symbol-name sym))))
+                  straight--build-default-steps))
          (straight-disable-info
           (member 'info           ,disabled))
          (straight-disable-compile
@@ -308,14 +308,14 @@ return nil."
 
 (straight-deftest straight--ensure-blank-lines ()
   (cl-flet ((buffer-with-point-at (s n)
-                                  (with-temp-buffer
-                                    (insert s)
-                                    (goto-char (point-min))
-                                    (when (search-forward "|" nil t)
-                                      (delete-region (match-beginning 0)
-                                                     (match-end 0)))
-                                    (straight--ensure-blank-lines n)
-                                    (buffer-string))))
+              (with-temp-buffer
+                (insert s)
+                (goto-char (point-min))
+                (when (search-forward "|" nil t)
+                  (delete-region (match-beginning 0)
+                                 (match-end 0)))
+                (straight--ensure-blank-lines n)
+                (buffer-string))))
     (should (equal ,buffer-string (buffer-with-point-at ,string ,n))))
   (string n buffer-string)
   "|beginning-of-buffer" 1 "beginning-of-buffer"

--- a/tests/straight-test.el
+++ b/tests/straight-test.el
@@ -650,6 +650,7 @@ return nil."
 ;; compile-command: "make -C ../"
 ;; create-lockfiles: nil
 ;; auto-save-default: nil
+;; indent-tabs-mode: nil
 ;; End:
 
 ;;; straight-test.el ends here

--- a/tests/straight-test.el
+++ b/tests/straight-test.el
@@ -206,7 +206,7 @@ return nil."
   (in) "test.el")
 
 (straight-deftest straight--build-steps ()
-  (let* ((defaults
+  (let* ((dflts
           (mapcar (lambda (sym)
                     (intern (string-remove-prefix "straight-disable-"
                                                   (symbol-name sym))))
@@ -219,7 +219,7 @@ return nil."
           (member 'autoloads      ,disabled))
          (straight-disable-native-compile
           (member 'native-compile ,disabled)))
-    (ignore defaults) ;;pacify byte-compiler
+    (ignore dflts   ) ;;pacify byte-compiler
     (should (equal (mapcar (lambda (step)
                              (intern (format "straight--build-%s"
                                              (symbol-name step))))
@@ -228,13 +228,13 @@ return nil."
                     '(:package "test" :build ,build)))))
   (disabled       build            steps)
   nil             nil              nil
-  defaults        nil              nil
-  nil             t                defaults
-  defaults        t                defaults
+  dflts           nil              nil
+  nil             t                dflts
+  dflts           t                dflts
   nil             (compile)        '(compile)
-  defaults        (autoloads info) '(autoloads info)
+  dflts           (autoloads info) '(autoloads info)
   nil             (:not compile)   '(autoloads native-compile info)
-  defaults        (:not compile)   nil
+  dflts           (:not compile)   nil
   '(info)         (:not compile)   '(autoloads native-compile))
 
 (straight-deftest straight--buildable-p ()


### PR DESCRIPTION
* Enable linting against Emacs 30 in CI
* Re-enable checkindent linter
* Update indentation so that it is the same in all Emacs versions 25-30
    * Check the comments in `indent.el` for an explanation of how
