### PR TITLE
Use prebuilt Docker images for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,6 @@ jobs:
         run: >-
           make docker
           CMD="make compile test smoke checkdoc longlines checkindent"
-          DOCKER_BASE=ghcr.io/radian-software/emacs-base
+          DOCKER_BASE=ghcr.io/radian-software/straight-ci
+          NO_BUILD_DOCKER=1
           NO_SUDO_DOCKER=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,9 @@ ARG BASE=silex/emacs
 ARG VERSION=30
 FROM $BASE:$VERSION
 
-ARG UID
-
 COPY scripts/docker-install.bash /tmp/
-RUN /tmp/docker-install.bash "$UID"
+RUN /tmp/docker-install.bash
 
-USER $UID
-WORKDIR /home/docker/src
+WORKDIR /src
 
 CMD bash

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ for the [Emacs] hacker.
 - [Trivia](#trivia)
   * [Comments and docstrings](#comments-and-docstrings)
 - [Contributing](#contributing)
+  * [CI administration](#ci-administration)
 - [FAQ](#faq)
   * [My init time got slower](#my-init-time-got-slower)
   * ["Could not find package in recipe repositories"](#could-not-find-package-in-recipe-repositories)
@@ -3432,6 +3433,31 @@ For additional information, please see [the contributor guide for my
 projects](https://github.com/radian-software/contributor-guide). Note
 that `straight.el` has not yet had an initial release, so you don't
 have to worry about a changelog.
+
+### CI administration
+
+Maintaining the GitHub Container Registry images used by CI looks like
+this for a given Emacs version. We have the base image:
+
+```
+docker pull silex/emacs:30
+docker tag silex/emacs:30 ghcr.io/radian-software/emacs-base:30
+docker push ghcr.io/radian-software/emacs-base:30
+```
+
+And the full image:
+
+```
+DOCKER_BASE=ghcr.io/radian-software/emacs-base  \
+  make docker VERSION=30 CMD="make lint test"
+docker tag straight.el:30 ghcr.io/radian-software/straight-ci:30
+docker push ghcr.io/radian-software/straight-ci:30
+```
+
+For this you of course need GHCR authentication, for example by
+generating a personal access token (classic) with the `packages:write`
+scope, and then `docker login https://ghcr.io -u yourlogin
+--password-stdin <<< yourtoken`.
 
 ## FAQ
 ### My init time got slower

--- a/scripts/docker-install.bash
+++ b/scripts/docker-install.bash
@@ -3,13 +3,6 @@
 set -e
 set -o pipefail
 
-if (( $# != 1 )); then
-    echo "usage: docker-install.bash UID" >&2
-    exit 1
-fi
-
-uid="$1"
-
 packages="
 
 # needed to run build system
@@ -39,8 +32,5 @@ apt-get install --no-install-recommends -y $(grep -v "^#" <<< "$packages")
 rm -rf /var/lib/apt/lists/*
 
 npm install -g markdown-toc
-
-useradd --uid="$uid" --create-home --groups sudo docker
-passwd -d docker
 
 rm "$0"

--- a/scripts/docker-pid1.bash
+++ b/scripts/docker-pid1.bash
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cat <<"EOF" > /etc/sudoers.d/straight
+%sudo ALL=(ALL:ALL) NOPASSWD: ALL
+EOF
+
+groupadd -g "$(stat -c %g "$PWD")" -o -p '!' -r straight
+useradd -u "$(stat -c %u "$PWD")" -g "$(stat -c %g "$PWD")" \
+        -o -p '!' -m -N -l -s /usr/bin/bash -G sudo straight
+
+runuser -u straight touch /home/straight/.sudo_as_admin_successful
+
+if (( "$#" == 0 )) || [[ -z "$1" ]]; then
+    set -- bash
+fi
+
+if (( "$#" == 1 )) && [[ "$1" == *" "* ]]; then
+    set -- bash -c "$1"
+fi
+
+exec runuser -u straight -- "$@"


### PR DESCRIPTION
This should speed things up significantly, because there's no reason to install a bunch of packages six times for each pull request, as opposed to just pulling images that are already built once and using those.
