### PR TITLE
Log Git commit correctly

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -637,8 +637,8 @@ accident."
           (condition-case err
               (let ((args (mapcar
                            (lambda (arg)
-                             (if (and (listp arg)
-                                      (functionp arg))
+                             (if (and (functionp arg)
+                                      (not (symbolp arg)))
                                  (funcall arg)
                                arg))
                            args)))


### PR DESCRIPTION
Lambdas can turn into compiled-bytecode when `straight.el` is byte-compiled, making the code for checking that the argument is a lambda no longer work. The objective was to avoid symbols being accidentally interpreted as functions, so change the implementation to check that more explicitly.