### PR TITLE
Provide useful logs after failed bootstrap

### DIFF
--- a/install.el
+++ b/install.el
@@ -146,7 +146,7 @@
              (error "Malformed version lockfile: %S" lockfile-name))))))
     (unless version
       ;; If no lockfile present, use latest version.
-      (setq version :gamma))
+      (setq version :delta))
     (with-current-buffer
         (url-retrieve-synchronously
          (format
@@ -185,7 +185,12 @@
                    (push sym vars))))
               (mapcar (lambda (var)
                         `(setq ,var ',(symbol-value var)))
-                      vars)))
+                      vars))
+          ;; Help with debugging. The user will not see any of these
+          ;; messages unless there is a catastrophic failure.
+          (setq straight-log t)
+          (setq straight-log-messages t)
+          (setq straight-process-messages t))
        (current-buffer))
       (goto-char (point-max))
       (print

--- a/straight-x.el
+++ b/straight-x.el
@@ -152,7 +152,7 @@
   (let ((lockfile-path (straight--versions-lockfile 'pinned)))
     (with-temp-file lockfile-path
       (insert
-       (format "(%s)\n:gamma\n"
+       (format "(%s)\n:delta\n"
                (mapconcat
                 (apply-partially #'format "%S")
                 straight-x-pinned-packages

--- a/straight.el
+++ b/straight.el
@@ -392,7 +392,8 @@ cannot be reproduced outside your system."
 
 (defcustom straight-log-messages nil
   "Non-nil means also write `straight-log-buffer' to `message'.
-This means all logging will also go to stderr in batch mode.")
+This means all logging will also go to stderr in batch mode."
+  :type 'boolean)
 
 ;;;; Utility functions
 ;;;;; Lists

--- a/straight.el
+++ b/straight.el
@@ -390,6 +390,10 @@ cannot be reproduced outside your system."
   "Name of logging buffer when `straight-log' is non-nil."
   :type 'string)
 
+(defcustom straight-log-messages nil
+  "Non-nil means also write `straight-log-buffer' to `message'.
+This means all logging will also go to stderr in batch mode.")
+
 ;;;; Utility functions
 ;;;;; Lists
 
@@ -633,7 +637,8 @@ accident."
       (save-excursion
         (goto-char (point-max))
         (let ((inhibit-read-only t)
-              (body nil))
+              (body nil)
+              (start (point)))
           (condition-case err
               (let ((args (mapcar
                            (lambda (arg)
@@ -650,7 +655,10 @@ accident."
            (format
             "%s <%S>: %s\n"
             (format-time-string "%Y-%m-%d %H:%M:%S.%3N" (current-time))
-            category body)))))))
+            category body))
+          (when straight-log-messages
+            (message "%s" (buffer-substring-no-properties
+                           start (point)))))))))
 
 ;;;;; Buffers
 
@@ -1022,6 +1030,12 @@ eaten by a grue.")
   "Name of buffer used for process output."
   :type 'string)
 
+(defcustom straight-process-messages nil
+  "Non-nil means also write `straight-process-buffer' to `message'.
+This means all process invocations and results will also go to stderr in
+batch mode."
+  :type 'boolean)
+
 (defun straight--delete-stderr-file ()
   "Remove `straight--process-stderr' file."
   (when (and (boundp 'straight--process-stderr)
@@ -1087,7 +1101,8 @@ ENTRY is a list of the form: (PROGRAM (ARGS...) (RESULT) DIRECTORY)
 If ERROR is non-nil, ENTRY's face is `straight-process-error'."
   (with-current-buffer (straight--process-buffer)
     (goto-char (point-max))
-    (pcase-let ((`(,program ,args ,result ,directory) entry))
+    (pcase-let ((`(,program ,args ,result ,directory) entry)
+                (start (point)))
       (straight--process-with-result result
         (let* ((inhibit-read-only t)
                (entry
@@ -1108,7 +1123,10 @@ If ERROR is non-nil, ENTRY's face is `straight-process-error'."
           (straight--ensure-blank-lines 2)
           (insert (if error
                       (propertize entry 'face 'straight-process-error)
-                    entry)))))))
+                    entry))))
+      (when straight-process-messages
+        (message "%s" (buffer-substring-no-properties
+                       start (point)))))))
 
 (defun straight--process-warn (entry &optional display)
   "Emit a warning for ENTRY.
@@ -1168,8 +1186,12 @@ If the command cannot be run or returns a nonzero exit code, throw an error."
         ;; Some programs may print to stderr even if they exit with 0.
         (let ((output (concat stdout stderr)))
           (if straight--process-trim (string-trim output) output))
-      (error "Failed to run %S; see buffer %s"
-             program straight-process-buffer))))
+      (error
+       "Failed to run %s, see %s"
+       (mapconcat #'shell-quote-argument (cons program args) " ")
+       (if straight-process-messages
+           "prior messages"
+         (format "buffer %s" straight-process-buffer))))))
 
 (defun straight--make-mtime (mtime)
   "Ensure that the `straight--mtimes-file' for MTIME (a string) exists.
@@ -6753,7 +6775,7 @@ according to the value of `straight-profiles'."
               ;;
               ;; The version keyword comes after the versions alist so
               ;; that you can ignore it if you don't need it.
-              "(%s)\n:gamma\n"
+              "(%s)\n:delta\n"
               (mapconcat
                (apply-partially #'format "%S")
                versions-alist


### PR DESCRIPTION
Now we get:

```
Debugger entered--Lisp error: (error "straight.el bootstrap failed, see *Messages*")
```

And in `*Messages*`:

```
Bootstrapping straight.el...
straight.el bootstrap failed with status 255, subprocess logs follow:
------2025-06-10 14:26:27.113 <modification-detection>: Loading build cache


2025-06-10 14:26:27.116 <vc>: Invoking VC method clone of type git with args: ((:type git :host github :repo "radian-software/straight.el" :branch "wip/bootstrap-logging" :package "straight\
" :local-repo "straight.el") nil)

2025-06-10 14:26:27.665 <process>: Got return status 128 from command: ("git" "clone" "--origin" "origin" "--no-checkout" "git@github.com:radian-software/straight.el.git" "/home/raxod502/fi\
les/temp/issue1063/straight/repos/straight.el/" "--no-single-branch" "--branch" "wip/bootstrap-logging")

$ cd /home/raxod502/files/temp/issue1063/straight/repos/
$ git clone --origin origin --no-checkout git\@github.com\:radian-software/straight.el.git /home/raxod502/files/temp/issue1063/straight/repos/straight.el/ --no-single-branch --branch wip/bo\
otstrap-logging

Cloning into '/home/raxod502/files/temp/issue1063/straight/repos/straight.el'...
ssh_askpass: exec(/usr/bin/ssh-askpass): No such file or directory^M
git@github.com: Permission denied (publickey).^M
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

[Return code: 128]

Cloning straight.el...

Error: error ("Failed to run git clone --origin origin --no-checkout git\\@github.com\\:radian-software/straight.el.git /home/raxod502/files/temp/issue1063/straight/repos/straight.el/ --no-\
single-branch --branch wip/bootstrap-logging, see prior messages")
```

Waaaaay better than the crud we had before, which would just tell you to look at a `*straight-process*` buffer that no longer existed.

Two other issues here -
* `Cloning straight.el...` is randomly at the end, instead of where it should be, due to https://github.com/radian-software/straight.el/issues/1200
* The reported error was a checkout error instead of a clone error, until I fixed https://github.com/radian-software/straight.el/pull/1201

This comes with an install script version bump from `:gamma` to `:delta`, because that's needed to cause the new version of the logging logic to be used during initial install.
