### PR TITLE
Improvements to recipe repo & inheritance handling

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -3937,11 +3937,17 @@ for dependency resolution."
                      ;; Emacs 28 and below.
                      (dflt
                       (or
-                       (when-let ((retrieved (straight-recipes-retrieve
-                                              package
-                                              (if (listp sources)
-                                                  sources
-                                                (list sources)))))
+                       (when-let
+                           ((retrieved
+                             (straight-recipes-retrieve
+                              package
+                              (if (listp sources)
+                                  sources
+                                (list sources))
+                              (concat cause
+                                      (when cause straight-arrow)
+                                      (format
+                                       "Checking for recipe inheritance")))))
                          ;; Recipes retrieved from files may be backquoted.
                          (cdr (if (straight--quoted-form-p retrieved)
                                   (eval retrieved) retrieved)))
@@ -6311,8 +6317,14 @@ include a nil `:build' property, to unconditionally
 inhibit the build phase.
 
 This function also adds the recipe repository to
-`straight-recipe-repositories', at the end of the list."
-  (straight-use-package-lazy melpa-style-recipe)
+`straight-recipe-repositories', at the end of the list.
+
+Existing recipe repositories are not searched for a recipe for the
+recipe repository you are trying to register, because that is strange
+and confusing. If you explicitly want this behavior, you can use the
+`straight-use-package' API directly."
+  (let ((straight-recipe-repositories nil))
+    (straight-use-package-lazy melpa-style-recipe))
   (add-to-list 'straight-recipe-repositories
                (if (listp melpa-style-recipe)
                    (car melpa-style-recipe)

--- a/straight.el
+++ b/straight.el
@@ -3947,7 +3947,8 @@ for dependency resolution."
                               (concat cause
                                       (when cause straight-arrow)
                                       (format
-                                       "Checking for recipe inheritance")))))
+                                       "Computing recipe inheritance for %S"
+                                       package)))))
                          ;; Recipes retrieved from files may be backquoted.
                          (cdr (if (straight--quoted-form-p retrieved)
                                   (eval retrieved) retrieved)))


### PR DESCRIPTION
Fixes https://github.com/radian-software/straight.el/issues/494.

New version of bootstrapping `straight.el` and installing `use-package` is much better:

```
Bootstrapping straight.el...done
Building straight...done
Looking for use-package recipe → Cloning melpa...done
Looking for use-package recipe → Cloning gnu-elpa-mirror...done
Cloning use-package...done
Building use-package...
Building use-package → Cloning bind-key...done
Building use-package → Building bind-key...done
Building use-package...done
```

And let's say you provided a custom recipe for `use-package` while still having recipe inheritance enabled:

```
Bootstrapping straight.el...done
Building straight...done
Computing recipe inheritance for use-package → Looking for use-package recipe → Cloning melpa...done
Computing recipe inheritance for use-package → Looking for use-package recipe → Cloning gnu-elpa-mirror...done
Cloning use-package...done
Building use-package...
Building use-package → Cloning bind-key...done
Building use-package → Building bind-key...done
Building use-package...done
```

Or with it disabled:

```
Bootstrapping straight.el...done
Building straight...done
Cloning use-package...done
Building use-package...
Building use-package → Looking for bind-key recipe → Cloning melpa...done
Building use-package → Looking for bind-key recipe → Cloning gnu-elpa-mirror...done
Building use-package → Cloning bind-key...done
Building use-package → Building bind-key...done
Building use-package...done
```

Or when looking up a package that doesn't exist:

```
Bootstrapping straight.el...done
Building straight...done
Looking for foobarbaz recipe → Cloning melpa...done
Looking for foobarbaz recipe → Cloning gnu-elpa-mirror...done
Looking for foobarbaz recipe → Cloning nongnu-elpa...done
Looking for foobarbaz recipe → Cloning el-get...done
Looking for foobarbaz recipe → Cloning emacsmirror-mirror...done
error: Could not find package foobarbaz. Updating recipe repositories: (org-elpa melpa gnu-elpa-mirror nongnu-elpa el-get emacsmirror-mirror) with ‘straight-pull-recipe-repositories’ may fix this
```
