### PR TITLE
Allow M-x straight-use-package already installed

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -6206,12 +6206,7 @@ hint about how to install the package permanently.
 Return non-nil when package is initially installed, nil otherwise."
   (interactive
    (list (straight-get-recipe
-          (when current-prefix-arg 'interactive) nil
-          (let ((installed nil))
-            ;; Cache keys are :local-repo. We want to compare :package.
-            (maphash (lambda (_ v) (push (plist-get v :package) installed))
-                     straight--repo-cache)
-            (lambda (pkg) (not (member pkg installed)))))
+          (when current-prefix-arg 'interactive) nil)
          nil nil nil 'interactive))
   ;; Do this unconditionally, at the very beginning, because we want
   ;; to have caches loaded right away - they're needed even for


### PR DESCRIPTION
In some cases (errors, partial installs, deferred installs) it may be desired to `M-x straight-use-package` on a package that's already registered in the cache. Don't prevent doing so.