### PR TITLE
Clear autoloads cache only on actual build

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -5763,8 +5763,6 @@ repository."
 RECIPE should be a straight.el-style plist. The build mtime and
 recipe in `straight--build-cache' for the package are updated."
   (straight--with-plist recipe (package)
-    ;; We've rebuilt the package, so its autoloads might have changed.
-    (remhash package straight--autoloads-cache)
     ;; This time format is compatible with:
     ;;
     ;; * BSD find shipped with macOS >=10.11
@@ -6411,7 +6409,9 @@ packages."
              (when (and modified (not no-build))
                (run-hook-with-args
                 'straight-use-package-pre-build-functions package)
-               (straight--build-package recipe cause))
+               (straight--build-package recipe cause)
+               ;; We've rebuilt the package, so its autoloads might have changed.
+               (remhash package straight--autoloads-cache))
              ;; We need to do this even if the package wasn't built,
              ;; so we can keep track of modifications.
              (straight--declare-successful-build recipe)

--- a/straight.el
+++ b/straight.el
@@ -6410,7 +6410,8 @@ packages."
                (run-hook-with-args
                 'straight-use-package-pre-build-functions package)
                (straight--build-package recipe cause)
-               ;; We've rebuilt the package, so its autoloads might have changed.
+               ;; We've rebuilt the package, so its autoloads might
+               ;; have changed.
                (remhash package straight--autoloads-cache))
              ;; We need to do this even if the package wasn't built,
              ;; so we can keep track of modifications.


### PR DESCRIPTION
Only wipe the autoloads cache after an actual build, not unconditionally, as doing the latter will result in the autoloads cache not actually being used when it can be.