### PR TITLE
Fix bad quoting in install script

### DIFF
--- a/install.el
+++ b/install.el
@@ -221,7 +221,7 @@
                    ;; (for some silly reason) move your
                    ;; `user-emacs-directory'.
                    (link-target (concat "repos/" local-repo "/bootstrap.el"))
-                   (link-name (concat straight-install-dir
+                   (link-name (concat ',straight-install-dir
                                       "straight/bootstrap.el")))
               (ignore-errors
                 ;; If it's a directory, the linking will fail. Just let


### PR DESCRIPTION
If `bootstrap-version` was not dynamically bound, then this code path would get triggered. Since that is rare, I guess nobody noticed that this variable was not actually defined as it was bound lexically and thus not propagated to the child Emacs process.