### PR TITLE
Remove numerous spiders from the transaction code

### DIFF
--- a/bootstrap.el
+++ b/bootstrap.el
@@ -68,6 +68,12 @@
 ;; feature has already been provided by loading straight.elc above.
 (require 'straight)
 
+;; Just in case the user loaded their init-file as part of a function
+;; that also previously called other straight.el functions, ensure
+;; that there is not old transaction state that will cause following
+;; calls to be interpreted non-functionally.
+(straight--transaction-finalize)
+
 (straight--log 'init "Loading bootstrap.el")
 (straight--log
  'env "Git commit: %s"
@@ -132,7 +138,11 @@
 ;; have any dependencies :) so let's keep it simple, and especially
 ;; make sure that any errors cloning the recipe repositories won't
 ;; block straight.el itself from loading.
-(mapc #'straight-use-recipes straight-initial-recipe-repositories)
+(mapc
+ (lambda (recipe)
+   (straight-use-recipes
+    recipe "Initial recipe repository registration"))
+ straight-initial-recipe-repositories)
 
 (if (straight--modifications 'check-on-save)
     (straight-live-modifications-mode +1)


### PR DESCRIPTION
Fix both of the issues reported in https://github.com/radian-software/straight.el/issues/677. Both of them were caused by some very subtle interactions. I made a number of other improvements to aid in resolution.

* We need to finalize any pending transactions in the bootstrap code, before resetting caches. Otherwise, if the user had registered other packages in the prior transaction, for example due to executing `straight-check-package` and then `straight-freeze-versions` in the same toplevel function, as in the issue report, then duplicate transaction detection can trigger and inadvertently prevent some packages from being re-registered during the init-file re-loading subroutine, causing them to be missing from the lockfile.
* In `straight--register-recipe`, we need to abort before invalidating the profile cache if the registered recipe is identical to what's already known. This prevents invocations of e.g. `straight-check-package` from triggering a request to re-load the init-file in `straight-freeze-versions` subsequently.
* Added logging to invocations of `straight-use-package`. Made some minor changes to thread through the `CAUSE` argument better, so it can help in log analysis.
* Added logging to the transaction system. Logs are getting pretty noisy now, but that's not an issue due to the category tags, which make it so you can easily filter out unneeded information, or jump to just the type you want. Tweaked the transaction IDs used by `straight-use-package` so they render more nicely in logs.
