### PR TITLE
Add cross-link to recipe format section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1949,7 +1949,6 @@ differences from the user's point of view are:
   built; see below.
 * There are consistency and feature improvements to edge cases of the
   `:files` keyword as documented in `straight-expand-files-directive`.
-
 * `:includes` indicates a package is a superset of another package.
 
 Here is a comprehensive list of all keywords which have special
@@ -3291,6 +3290,9 @@ this syntax instead by customizing `straight-use-package-version`.
 
 You can disable `use-package` integration entirely by customizing
 `straight-enable-use-package-integration`.
+
+For more details on the available keywords inside a recipe, see [the
+recipe format][#user/recipes].
 
 ##### Loading packages conditionally
 


### PR DESCRIPTION
I think the information requested in https://github.com/radian-software/straight.el/issues/1078 is already present in the documentation; it just isn't located in the `use-package` section, because it's not specific to `use-package`; rather, the `use-package` integration simply allows you to use any recipe keywords supported by `straight.el`. Accordingly, I've added a cross-link to that section.

Please let me know what else is missing, and I will augment the documentation.