### PR TITLE
Fix: Update git submodules during package upgrades

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -2473,6 +2473,13 @@ prefixed with a remote name."
                   local-repo default-branch
                   (format "%s/%s" remote-to-merge remote-branch))
                  (straight-register-repo-modification local-repo))
+             (progn
+               ;; Update submodules if .gitmodules exists after merge
+               (when (file-exists-p
+                      (expand-file-name ".gitmodules"
+                                        (straight--repos-dir local-repo)))
+                 (straight--process-output "git" "submodule" "update" "--init" "--recursive"))
+               t)
              (cl-return-from straight-vc-git--merge-from-remote-raw t))))))
 
 (cl-defun straight-vc-git--pull-from-remote-raw (recipe remote remote-branch)

--- a/straight.el
+++ b/straight.el
@@ -2478,7 +2478,8 @@ prefixed with a remote name."
                (when (file-exists-p
                       (expand-file-name ".gitmodules"
                                         (straight--repos-dir local-repo)))
-                 (straight--process-output "git" "submodule" "update" "--init" "--recursive"))
+                 (straight--process-output
+                  "git" "submodule" "update" "--init" "--recursive"))
                t)
              (cl-return-from straight-vc-git--merge-from-remote-raw t))))))
 


### PR DESCRIPTION
Fix: Update git submodules during package upgrades

Fixes #238

## Problem

Straight.el runs `git submodule update --init --recursive` during initial clone but doesn't update submodules during package upgrades. When upstream repositories update submodule pointers, local submodules remain at old commits, causing repositories to appear dirty.

This addresses issue #238. Related issues include #502 and external reports like kaushalmodi/ox-hugo#346 where users encounter persistent submodule conflicts during upgrades.

## Example

The `gptel` package uses a test submodule. After upstream updates the submodule pointer, doom upgrade prompts:

```
> Repository "gptel" has a dirty worktree:
    
       M test

         1) Abort
         2) Stash changes  
         3) Discard changes
```

## Solution

Add `git submodule update --init --recursive` after merges in `straight-vc-git--merge-from-remote-raw` when `.gitmodules` exists.

## Implementation

```elisp
;; In straight-vc-git--merge-from-remote-raw:
(when (file-exists-p
       (expand-file-name ".gitmodules"
                         (straight--repos-dir local-repo)))
  (straight--process-output "git" "submodule" "update" "--init" "--recursive"))
```

## Testing

Tested with both existing and new submodules:

**Existing submodule scenario:**
- Before fix: Required manual "Discard changes" on every upgrade
- After fix: Manual resolution once, then submodules stay in sync automatically

**New submodule scenario:**
- Added test submodule to tracked repository
- doom upgrade automatically initialized submodule without prompts
- Updated submodule pointer to new commit  
- doom upgrade automatically synced to new commit without prompts

Fix successfully prevents submodule pointer mismatches for both scenarios.

No impact on repositories without submodules.