### PR TITLE
Improve NonGNU ELPA recipes from MELPA further

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -3833,6 +3833,7 @@ Otherwise return nil."
 
 ;;;;;; MELPA
 
+(defvar straight-recipes-nongnu-elpa-url)
 (defun straight-recipes-melpa-retrieve (package)
   "Look up a PACKAGE recipe in MELPA.
 PACKAGE should be a symbol. If the package has a recipe listed in

--- a/straight.el
+++ b/straight.el
@@ -3876,7 +3876,9 @@ return nil."
               (when (equal
                      (plist-get melpa-plist :url)
                      "https://git.savannah.gnu.org/git/emacs/nongnu.git")
-                (straight--put plist :local-repo (symbol-name package)))
+                (straight--put plist :local-repo (symbol-name package))
+                (straight--put plist :repo straight-recipes-nongnu-elpa-url)
+                (straight--put plist :depth '(full single-branch)))
               (cons name plist))))
       (error nil))))
 


### PR DESCRIPTION
Automatically detect NonGNU ELPA recipes in MELPA, and tweak them to respect the user's configuration for which NonGNU ELPA repository to use, which defaults to a more performant mirror than upstream. Also set the shallow clone configuration to one that is suitable for the NonGNU ELPA repository.

Closes https://github.com/radian-software/straight.el/issues/1259