### PR TITLE
Fix: Warning: ‘when-let’ is an obsolete macro

### DIFF
--- a/straight.el
+++ b/straight.el
@@ -3640,7 +3640,7 @@ cloned."
             ;; prevent us from checking the other recipe repositories.
             (when-let* ((recipe (gethash package table)))
               (cl-return recipe))
-          (when-let
+          (when-let*
               ((recipe
                 ;; NB: we use strings for the package names. This is
                 ;; not just for convenience; it also allows us to
@@ -4459,7 +4459,7 @@ for dependency resolution."
                      ;; Emacs 28 and below.
                      (dflt
                       (or
-                       (when-let
+                       (when-let*
                            ((retrieved
                              (straight-recipes-retrieve
                               package


### PR DESCRIPTION
This pull request fixes the warning: ‘when-let’ is an obsolete macro:

- straight.el:3643:12: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
- straight.el:4462:25: Warning: ‘when-let’ is an obsolete macro (as of 31.1); use ‘when-let*’ or ‘and-let*’ instead.
